### PR TITLE
feat: Add promotion type property

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Reference the schema directly in your manifest file:
   "services": [
     {
       "serviceTag": "my-service",
+      "promotionType": "securePipelines",
       "qualityGates": [
         {
           "checkTypes": ["unit"],

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,19 +29,19 @@ A quality gate is an enforced check that must pass before code progresses to the
 - A **provider** identifying the platform that executes it
 - A **config** pointing to where the check is defined
 
-### Branching strategy models
+#### Deployment strategy
 
-The schema supports three branching strategy models, each with different phase definitions:
+The schema supports three deployment strategy models, each with different phase definitions. The `promotionType` property on a service determines which phases are valid:
 
-| Model           | Use case                               | Phases                                                              |
-|-----------------|----------------------------------------|---------------------------------------------------------------------|
-| **Trunk-based** | Teams deploying continuously from main | pre-merge → pre-upload → build → staging → production → integration |
-| **Gitflow**     | Teams using develop/release branches   | pre-develop → develop → pre-release → release → main                |
-| **Library SDK** | Teams publishing packages              | pre-merge → pre-release                                             |
+| `promotionType`    | Use case                               | Phases                                                              |
+|--------------------|----------------------------------------|---------------------------------------------------------------------|
+| `securePipelines`  | Teams deploying continuously from main | pre-merge → pre-upload → build → staging → production → integration |
+| `gitFlow`          | Teams using develop/release branches   | pre-develop → develop → pre-release → release → main                |
+| `library`          | Teams publishing packages              | pre-merge → pre-release                                             |
 
 ### Check type taxonomy
 
-Check types are drawn from prior analyis work within the GOV.UK One Login programme. They represent categories of verification, not specific tools. For example, `unit` covers any unit testing framework, and `secret scanning` covers any tool that detects secrets.
+Check types are drawn from prior analysis work within the GOV.UK One Login programme. They represent categories of verification, not specific tools. For example, `unit` covers any unit testing framework, and `secret scanning` covers any tool that detects secrets.
 
 ## Design decisions
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -36,10 +36,11 @@ Most JSON editors support `$schema` for autocompletion and validation. For VS Co
 
 A manifest contains an array of **services**, each with:
 
-| Field           | Type   | Description                      |
-|-----------------|--------|----------------------------------|
-| `serviceTag`    | string | Short identifier for the service |
-| `quality-gates` | array  | List of quality gate checks      |
+| Field           | Type   | Description                                                  |
+|-----------------|--------|--------------------------------------------------------------|
+| `serviceTag`    | string | Short identifier for the service                             |
+| `promotionType` | string | Promotion strategy (`securePipelines`, `gitFlow`, `library`) |
+| `qualityGates`  | array  | List of quality gate checks                                  |
 
 Each **quality gate** contains:
 
@@ -58,13 +59,13 @@ The schema supports the following check-type values:
 
 ### Phases
 
-Phases vary by branching strategy:
+Valid phases depend on the service's `promotionType`:
 
-| Strategy    | Phases                                                                     |
-|-------------|----------------------------------------------------------------------------|
-| Trunk-based | `pre-merge`, `pre-upload`, `build`, `staging`, `production`, `integration` |
-| Gitflow     | `pre-develop`, `develop`, `pre-release`, `release`, `main`                 |
-| Library SDK | `pre-merge`, `pre-release`                                                 |
+| `promotionType`    | Valid phases                                                               |
+|--------------------|----------------------------------------------------------------------------|
+| `securePipelines`  | `pre-merge`, `pre-upload`, `build`, `staging`, `production`, `integration` |
+| `gitFlow`          | `pre-develop`, `develop`, `pre-release`, `release`, `main`                 |
+| `library`          | `pre-merge`, `pre-release`                                                 |
 
 ### Config object
 

--- a/examples/github-gitflow.json
+++ b/examples/github-gitflow.json
@@ -2,6 +2,7 @@
   "services": [
     {
       "serviceTag": "service-name",
+      "promotionType": "gitFlow",
       "qualityGates": [
         {
           "checkTypes": ["unit"],

--- a/examples/github-librarysdk.json
+++ b/examples/github-librarysdk.json
@@ -2,6 +2,7 @@
   "services": [
     {
       "serviceTag": "service-name",
+      "promotionType": "library",
       "qualityGates": [
         {
           "checkTypes": ["unit"],

--- a/examples/github-trunk.json
+++ b/examples/github-trunk.json
@@ -2,6 +2,7 @@
   "services": [
     {
       "serviceTag": "service-name",
+      "promotionType": "securePipelines",
       "qualityGates": [
         {
           "checkTypes": ["unit"],

--- a/examples/github.json
+++ b/examples/github.json
@@ -2,6 +2,7 @@
   "services": [
     {
       "serviceTag": "service-name",
+      "promotionType": "securePipelines",
       "qualityGates": [
         {
           "checkTypes": ["code style and linting"],

--- a/quality-gate.manifest.json
+++ b/quality-gate.manifest.json
@@ -3,6 +3,7 @@
   "services": [
     {
       "serviceTag": "quality-gates",
+      "promotionType": "library",
       "qualityGates": [
         {
           "checkTypes": ["unit"],

--- a/schemas/schema.json
+++ b/schemas/schema.json
@@ -7,6 +7,7 @@
       "services": [
         {
           "serviceTag": "service-name",
+          "promotionType": "securePipelines",
           "qualityGates": [
             {
               "checkTypes": ["code style and linting"],
@@ -34,36 +35,7 @@
           "$ref": "#/$defs/check-type"
         },
         "phase": {
-          "items": {
-            "type": "string",
-            "oneOf": [
-            {
-              "enum": [
-                "pre-merge",
-                "pre-upload",
-                "build",
-                "staging",
-                "production",
-                "integration"
-              ]
-            },
-            {
-              "enum": [
-                "pre-develop",
-                "develop",
-                "pre-release",
-                "release",
-                "main"
-              ]
-            },
-            {
-              "enum": [
-                "pre-merge",
-                "pre-release"
-              ]
-            }
-          ]
-          }
+          "type": "string"
         },
         "provider": {
           "enum": [
@@ -140,7 +112,8 @@
     "service": {
       "required": [
         "qualityGates",
-        "serviceTag"
+        "serviceTag",
+        "promotionType"
       ],
       "properties": {
         "qualityGates": {
@@ -151,8 +124,86 @@
         },
         "serviceTag": {
           "type": "string"
+        },
+        "promotionType": {
+          "enum": [
+            "securePipelines",
+            "gitFlow",
+            "library"
+          ]
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "promotionType": {
+                "const": "securePipelines"
+              }
+            },
+            "required": ["promotionType"]
+          },
+          "then": {
+            "properties": {
+              "qualityGates": {
+                "items": {
+                  "properties": {
+                    "phase": {
+                      "enum": ["pre-merge", "pre-upload", "build", "staging", "production", "integration"]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "promotionType": {
+                "const": "gitFlow"
+              }
+            },
+            "required": ["promotionType"]
+          },
+          "then": {
+            "properties": {
+              "qualityGates": {
+                "items": {
+                  "properties": {
+                    "phase": {
+                      "enum": ["pre-develop", "develop", "pre-release", "release", "main"]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "promotionType": {
+                "const": "library"
+              }
+            },
+            "required": ["promotionType"]
+          },
+          "then": {
+            "properties": {
+              "qualityGates": {
+                "items": {
+                  "properties": {
+                    "phase": {
+                      "enum": ["pre-merge", "pre-release"]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
     },
     "services": {
       "type": "array",

--- a/test/check-types.json
+++ b/test/check-types.json
@@ -9,6 +9,7 @@
         "services": [
           {
             "serviceTag": "generic-service",
+            "promotionType": "securePipelines",
             "qualityGates": [
               {
                 "checkTypes": ["integration"],
@@ -32,6 +33,7 @@
         "services": [
           {
             "serviceTag": "generic-service",
+            "promotionType": "securePipelines",
             "qualityGates": [
               {
                 "checkTypes": ["component"],
@@ -55,6 +57,7 @@
         "services": [
           {
             "serviceTag": "generic-service",
+            "promotionType": "securePipelines",
             "qualityGates": [
               {
                 "checkTypes": ["product"],
@@ -78,6 +81,7 @@
         "services": [
           {
             "serviceTag": "generic-service",
+            "promotionType": "securePipelines",
             "qualityGates": [
               {
                 "checkTypes": ["neighbour"],
@@ -101,6 +105,7 @@
         "services": [
           {
             "serviceTag": "generic-service",
+            "promotionType": "securePipelines",
             "qualityGates": [
               {
                 "checkTypes": ["e2e"],

--- a/test/gitflow.json
+++ b/test/gitflow.json
@@ -9,6 +9,7 @@
         "services": [
           {
             "serviceTag": "generic-service",
+            "promotionType": "gitFlow",
             "qualityGates": [
               {
                 "checkTypes": ["unit"],

--- a/test/librarysdk.json
+++ b/test/librarysdk.json
@@ -9,6 +9,7 @@
         "services": [
           {
             "serviceTag": "generic-library",
+            "promotionType": "library",
             "qualityGates": [
               {
                 "checkTypes": ["unit"],

--- a/test/promotion-type.json
+++ b/test/promotion-type.json
@@ -1,0 +1,165 @@
+{
+  "target": "../schemas/schema.json",
+  "$comment": "promotionType conditional phase validation tests",
+  "tests": [
+    {
+      "description": "securePipelines with valid phase staging",
+      "valid": true,
+      "data": {
+        "services": [
+          {
+            "serviceTag": "service",
+            "promotionType": "securePipelines",
+            "qualityGates": [
+              {
+                "checkTypes": ["unit"],
+                "provider": "GitHub",
+                "phase": "staging",
+                "config": { "file": "test.yaml" }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "description": "securePipelines with invalid phase develop",
+      "valid": false,
+      "data": {
+        "services": [
+          {
+            "serviceTag": "service",
+            "promotionType": "securePipelines",
+            "qualityGates": [
+              {
+                "checkTypes": ["unit"],
+                "provider": "GitHub",
+                "phase": "develop",
+                "config": { "file": "test.yaml" }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "description": "gitFlow with valid phase develop",
+      "valid": true,
+      "data": {
+        "services": [
+          {
+            "serviceTag": "service",
+            "promotionType": "gitFlow",
+            "qualityGates": [
+              {
+                "checkTypes": ["unit"],
+                "provider": "GitHub",
+                "phase": "develop",
+                "config": { "file": "test.yaml" }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "description": "gitFlow with invalid phase staging",
+      "valid": false,
+      "data": {
+        "services": [
+          {
+            "serviceTag": "service",
+            "promotionType": "gitFlow",
+            "qualityGates": [
+              {
+                "checkTypes": ["unit"],
+                "provider": "GitHub",
+                "phase": "staging",
+                "config": { "file": "test.yaml" }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "description": "library with valid phase pre-merge",
+      "valid": true,
+      "data": {
+        "services": [
+          {
+            "serviceTag": "service",
+            "promotionType": "library",
+            "qualityGates": [
+              {
+                "checkTypes": ["unit"],
+                "provider": "GitHub",
+                "phase": "pre-merge",
+                "config": { "file": "test.yaml" }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "description": "library with invalid phase build",
+      "valid": false,
+      "data": {
+        "services": [
+          {
+            "serviceTag": "service",
+            "promotionType": "library",
+            "qualityGates": [
+              {
+                "checkTypes": ["unit"],
+                "provider": "GitHub",
+                "phase": "build",
+                "config": { "file": "test.yaml" }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "description": "service without promotionType is invalid",
+      "valid": false,
+      "data": {
+        "services": [
+          {
+            "serviceTag": "service",
+            "qualityGates": [
+              {
+                "checkTypes": ["unit"],
+                "provider": "GitHub",
+                "phase": "pre-merge",
+                "config": { "file": "test.yaml" }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "description": "service with unknown promotionType is invalid",
+      "valid": false,
+      "data": {
+        "services": [
+          {
+            "serviceTag": "service",
+            "promotionType": "unknown",
+            "qualityGates": [
+              {
+                "checkTypes": ["unit"],
+                "provider": "GitHub",
+                "phase": "pre-merge",
+                "config": { "file": "test.yaml" }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/trunk.json
+++ b/test/trunk.json
@@ -31,6 +31,7 @@
         "services": [
           {
             "serviceTag": "generic-service",
+            "promotionType": "securePipelines",
             "qualityGates": [
               {
                 "checkTypes": ["unit"],
@@ -54,6 +55,7 @@
         "services": [
           {
             "serviceTag": "generic-service-1",
+            "promotionType": "securePipelines",
             "qualityGates": [
               {
                 "checkTypes": ["code style and linting"],
@@ -69,6 +71,7 @@
           },
           {
             "serviceTag": "generic-service-2",
+            "promotionType": "securePipelines",
             "qualityGates": [
               {
                 "checkTypes": ["code style and linting"],
@@ -92,6 +95,7 @@
         "services": [
           {
             "serviceTag": "generic-service",
+            "promotionType": "securePipelines",
             "qualityGates": [
               {
                 "checkTypes": ["code style and linting"],
@@ -107,6 +111,7 @@
           },
           {
             "serviceTag": "generic-service",
+            "promotionType": "securePipelines",
             "qualityGates": [
               {
                 "checkTypes": ["code style and linting"],
@@ -130,6 +135,7 @@
         "services": [
           {
             "serviceTag": "generic-service",
+            "promotionType": "securePipelines",
             "qualityGates": [
               {
                 "checkTypes": ["unknown"],


### PR DESCRIPTION
Add promotion type property and use it to determine valid options for phase.

There are three types of promotion available:
- securePipelines - this is uses continuous deployment to reach live
- gitFlow - this uses release branches to reach live
- library - this uses a tagged release off the main branch