### PR TITLE
Use JSONPath for path instead of implicit JMESPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Reference the schema directly in your manifest file:
           "provider": "GitHub",
           "config": {
             "file": ".github/workflows/test.yml",
-            "path": "jobs.test"
+            "path": "$.jobs.test"
           }
         }
       ]

--- a/cli/commands/upgrade.test.js
+++ b/cli/commands/upgrade.test.js
@@ -33,7 +33,7 @@ describe("upgrade command", () => {
     assert.equal(result.services[0].serviceTag, "svc");
     assert.equal(result.services[0].promotionType, "securePipelines");
     assert.deepEqual(result.services[0].checks[0].checkTypes, ["unit"]);
-    assert.match(result.$schema, /v0\.10\.0/);
+    assert.match(result.$schema, /v0\.11\.0/);
   });
 
   it("does not write files in dry-run mode", () => {
@@ -62,7 +62,7 @@ describe("upgrade command", () => {
 
   it("skips manifests already at latest version", () => {
     const file = createManifest(TMP, {
-      $schema: "https://raw.githubusercontent.com/govuk-one-login/quality-gates/refs/tags/v0.10.0/schemas/schema.json",
+      $schema: "https://raw.githubusercontent.com/govuk-one-login/quality-gates/refs/tags/v0.11.0/schemas/schema.json",
       services: [{ serviceTag: "x", promotionType: "securePipelines", checks: [] }],
     });
     const before = readFileSync(file, "utf8");
@@ -86,8 +86,8 @@ describe("upgrade command", () => {
 
     const a = JSON.parse(readFileSync(join(TMP, "a", "quality-gate.manifest.json"), "utf8"));
     const b = JSON.parse(readFileSync(join(TMP, "b", "quality-gate.manifest.json"), "utf8"));
-    assert.match(a.$schema, /v0\.10\.0/);
-    assert.match(b.$schema, /v0\.10\.0/);
+    assert.match(a.$schema, /v0\.11\.0/);
+    assert.match(b.$schema, /v0\.11\.0/);
     assert.equal(b.services[0].serviceTag, "b");
   });
 

--- a/cli/formatters/json.js
+++ b/cli/formatters/json.js
@@ -2,10 +2,20 @@ import { suggest } from "../utils/suggest.js";
 
 export function formatJson(errors) {
   const enriched = errors.map((e) => {
-    const input = e.type === "missing-workflow"
-      ? e.details.file
-      : e.details.path?.split(".")[1];
-    const match = input ? suggest(input, e.details.available || []) : null;
+    let input, candidates;
+    if (e.type === "missing-workflow") {
+      input = e.details.file;
+      candidates = e.details.available || [];
+    } else if (e.type === "mismatched-job") {
+      input = e.details.path?.match(/\.jobs[.['"]]*([^.'"\]]+)/)?.[1];
+      candidates = e.details.available || [];
+    } else if (e.type === "mismatched-step") {
+      input = e.details.step?.value;
+      candidates = (e.details.available || []).map((a) => a.split(":").slice(1).join(":"));
+    } else {
+      return e;
+    }
+    const match = input ? suggest(input, candidates) : null;
     return match ? { ...e, suggestion: match } : e;
   });
 

--- a/cli/formatters/json.test.js
+++ b/cli/formatters/json.test.js
@@ -6,8 +6,8 @@ describe("formatJson", () => {
   it("returns valid JSON with summary and errors", () => {
     const errors = [
       { type: "missing-workflow", service: "svc", message: "m", details: { file: "x.yml", available: [] } },
-      { type: "mismatched-job", service: "svc", message: "m", details: { path: "jobs.x", workflow: "ci.yml", available: [] } },
-      { type: "mismatched-job", service: "svc", message: "m", details: { path: "jobs.y", workflow: "ci.yml", available: [] } },
+      { type: "mismatched-job", service: "svc", message: "m", details: { path: "$.jobs.x", workflow: "ci.yml", available: [] } },
+      { type: "mismatched-job", service: "svc", message: "m", details: { path: "$.jobs.y", workflow: "ci.yml", available: [] } },
     ];
     const result = JSON.parse(formatJson(errors));
     assert.equal(result.summary.total, 3);
@@ -42,5 +42,16 @@ describe("formatJson", () => {
     }];
     const result = JSON.parse(formatJson(errors));
     assert.equal(result.errors[0].suggestion, undefined);
+  });
+
+  it("counts new error types in summary", () => {
+    const errors = [
+      { type: "mismatched-step", service: "svc", message: "m", details: { path: "$.jobs.build.steps[?@.name=='X']", job: "build", step: { by: "name", value: "X" }, workflow: "ci.yml", available: ["name:Y"] } },
+      { type: "invalid-path-syntax", service: "svc", message: "m", details: { path: "bad" } },
+    ];
+    const result = JSON.parse(formatJson(errors));
+    assert.equal(result.summary.total, 2);
+    assert.equal(result.summary.byType["mismatched-step"], 1);
+    assert.equal(result.summary.byType["invalid-path-syntax"], 1);
   });
 });

--- a/cli/formatters/text.js
+++ b/cli/formatters/text.js
@@ -13,13 +13,27 @@ export function formatText(errors) {
       if (match) lines.push(`   Did you mean: ${match}?`);
       lines.push(`   Available workflows: ${error.details.available.join(", ")}`);
     } else if (error.type === "mismatched-job") {
-      const jobKey = error.details.path.split(".")[1];
-      lines.push(`❌ Invalid job path: ${error.details.path}`);
+      lines.push(`❌ Job not found: ${error.details.path}`);
       lines.push(`   Service: ${error.service}`);
       lines.push(`   Workflow: ${error.details.workflow}`);
-      const match = suggest(jobKey, error.details.available);
-      if (match) lines.push(`   Did you mean: jobs.${match}?`);
+      const jobKey = error.details.path.match(/\.jobs[.['"]]*([^.'"\]]+)/)?.[1];
+      const match = jobKey ? suggest(jobKey, error.details.available) : null;
+      if (match) lines.push(`   Did you mean: $.jobs.${match}?`);
       lines.push(`   Available jobs: ${error.details.available.join(", ")}`);
+    } else if (error.type === "mismatched-step") {
+      lines.push(`❌ Step not found: ${error.details.path}`);
+      lines.push(`   Service: ${error.service}`);
+      lines.push(`   Workflow: ${error.details.workflow}`);
+      lines.push(`   Job: ${error.details.job}`);
+      const stepValue = error.details.step.value;
+      const candidates = error.details.available.map((a) => a.split(":").slice(1).join(":"));
+      const match = suggest(stepValue, candidates);
+      if (match) lines.push(`   Did you mean: ${match}?`);
+      lines.push(`   Available steps: ${error.details.available.join(", ")}`);
+    } else if (error.type === "invalid-path-syntax") {
+      lines.push(`❌ Invalid path syntax: ${error.details.path}`);
+      lines.push(`   Service: ${error.service}`);
+      lines.push(`   Expected format: $.jobs.<name> or $.jobs.<name>.steps[?@.name=='<step>']`);
     }
     lines.push("");
   }

--- a/cli/formatters/text.test.js
+++ b/cli/formatters/text.test.js
@@ -23,18 +23,41 @@ describe("formatText", () => {
     const output = formatText([{
       type: "mismatched-job",
       service: "my-svc",
-      message: "Job not found: jobs.deploy",
-      details: { path: "jobs.deploy", workflow: "ci.yml", available: ["build", "test"] },
+      message: "Job not found: $.jobs.deploy",
+      details: { path: "$.jobs.deploy", workflow: "ci.yml", available: ["build", "test"] },
     }]);
-    assert.match(output, /Invalid job path: jobs\.deploy/);
+    assert.match(output, /Job not found: \$\.jobs\.deploy/);
     assert.match(output, /Workflow: ci\.yml/);
     assert.match(output, /Available jobs: build, test/);
+  });
+
+  it("formats mismatched-step errors", () => {
+    const output = formatText([{
+      type: "mismatched-step",
+      service: "my-svc",
+      message: "Step not found",
+      details: { path: "$.jobs.build.steps[?@.name=='Run tests']", job: "build", step: { by: "name", value: "Run tests" }, workflow: "ci.yml", available: ["name:Checkout", "name:Lint"] },
+    }]);
+    assert.match(output, /Step not found/);
+    assert.match(output, /Job: build/);
+    assert.match(output, /Available steps: name:Checkout, name:Lint/);
+  });
+
+  it("formats invalid-path-syntax errors", () => {
+    const output = formatText([{
+      type: "invalid-path-syntax",
+      service: "my-svc",
+      message: "Invalid JSONPath syntax",
+      details: { path: "$.invalid[syntax" },
+    }]);
+    assert.match(output, /Invalid path syntax: \$\.invalid\[syntax/);
+    assert.match(output, /Expected format/);
   });
 
   it("shows error count in header", () => {
     const errors = [
       { type: "missing-workflow", service: "a", message: "", details: { file: "x.yml", available: [] } },
-      { type: "mismatched-job", service: "b", message: "", details: { path: "jobs.x", workflow: "y.yml", available: [] } },
+      { type: "mismatched-job", service: "b", message: "", details: { path: "$.jobs.x", workflow: "y.yml", available: [] } },
     ];
     assert.match(formatText(errors), /Found 2 validation errors/);
   });
@@ -64,8 +87,8 @@ describe("formatText", () => {
       type: "mismatched-job",
       service: "svc",
       message: "",
-      details: { path: "jobs.run-pre-commit", workflow: "ci.yml", available: ["pre-commit", "unit-tests"] },
+      details: { path: "$.jobs.run-pre-commit", workflow: "ci.yml", available: ["pre-commit", "unit-tests"] },
     }]);
-    assert.match(output, /Did you mean: jobs\.pre-commit\?/);
+    assert.match(output, /Did you mean: \$\.jobs\.pre-commit\?/);
   });
 });

--- a/cli/middleware/load-workflows.js
+++ b/cli/middleware/load-workflows.js
@@ -7,10 +7,21 @@ export function loadWorkflows(argv) {
     const dir = join(argv.directory, ".github", "workflows");
     argv.workflows = readdirSync(dir)
       .filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))
-      .map((name) => ({
-        name,
-        jobs: YAML.parse(readFileSync(join(dir, name), "utf8")).jobs ?? {},
-      }));
+      .map((name) => {
+        const parsed = YAML.parse(readFileSync(join(dir, name), "utf8"));
+        const jobs = {};
+        for (const [key, job] of Object.entries(parsed.jobs ?? {})) {
+          jobs[key] = {
+            steps: (job.steps ?? []).map(({ id, name }) => {
+              const step = {};
+              if (id) step.id = id;
+              if (name) step.name = name;
+              return step;
+            }),
+          };
+        }
+        return { name, jobs };
+      });
   } catch {
     argv.workflows = [];
   }

--- a/cli/middleware/load-workflows.test.js
+++ b/cli/middleware/load-workflows.test.js
@@ -12,6 +12,18 @@ describe("loadWorkflows", () => {
     assert.ok(typeof argv.workflows[0].jobs === "object");
   });
 
+  it("extracts step name and id from jobs", () => {
+    const argv = { directory: ".." };
+    loadWorkflows(argv);
+    const workflow = argv.workflows.find((w) => w.name === "schema.yml");
+    assert.ok(workflow);
+    const job = workflow.jobs["run-tests"];
+    assert.ok(job);
+    assert.ok(Array.isArray(job.steps));
+    assert.ok(job.steps.length > 0);
+    assert.ok(job.steps.some((s) => s.name));
+  });
+
   it("sets argv.workflows to [] when dir does not exist", () => {
     const argv = { directory: "/nonexistent" };
     loadWorkflows(argv);

--- a/cli/upgrades/index.js
+++ b/cli/upgrades/index.js
@@ -2,6 +2,7 @@ import { transform as v050 } from "./v0.5.0.js";
 import { transform as v070 } from "./v0.7.0.js";
 import { transform as v090 } from "./v0.9.0.js";
 import { transform as v0100 } from "./v0.10.0.js";
+import { transform as v0110 } from "./v0.11.0.js";
 
 const SCHEMA_URL_PREFIX = "https://raw.githubusercontent.com/govuk-one-login/quality-gates/refs/tags/v";
 
@@ -10,6 +11,7 @@ const transforms = [
   { version: [0, 7, 0], transform: v070 },
   { version: [0, 9, 0], transform: v090 },
   { version: [0, 10, 0], transform: v0100 },
+  { version: [0, 11, 0], transform: v0110 },
 ];
 
 export function parseVersion(schema) {

--- a/cli/upgrades/upgrades.test.js
+++ b/cli/upgrades/upgrades.test.js
@@ -5,6 +5,7 @@ import { transform as v050 } from "./v0.5.0.js";
 import { transform as v070 } from "./v0.7.0.js";
 import { transform as v090 } from "./v0.9.0.js";
 import { transform as v0100 } from "./v0.10.0.js";
+import { transform as v0110 } from "./v0.11.0.js";
 
 describe("parseVersion", () => {
   it("extracts version from schema URL", () => {
@@ -20,23 +21,26 @@ describe("parseVersion", () => {
 
 describe("getTransforms", () => {
   it("returns all transforms for null version", () => {
-    assert.equal(getTransforms(null).length, 4);
+    assert.equal(getTransforms(null).length, 5);
   });
   it("returns all transforms for v0.1.0", () => {
-    assert.equal(getTransforms([0, 1, 0]).length, 4);
+    assert.equal(getTransforms([0, 1, 0]).length, 5);
   });
-  it("returns v0.7.0 and v0.9.0 and v0.10.0 for v0.5.0", () => {
+  it("returns v0.7.0 and v0.9.0 and v0.10.0 and v0.11.0 for v0.5.0", () => {
     const t = getTransforms([0, 5, 0]);
-    assert.equal(t.length, 3);
+    assert.equal(t.length, 4);
   });
-  it("returns v0.9.0 and v0.10.0 for v0.7.0", () => {
-    assert.equal(getTransforms([0, 7, 0]).length, 2);
+  it("returns v0.9.0 and v0.10.0 and v0.11.0 for v0.7.0", () => {
+    assert.equal(getTransforms([0, 7, 0]).length, 3);
   });
-  it("returns only v0.10.0 for v0.9.0", () => {
-    assert.equal(getTransforms([0, 9, 0]).length, 1);
+  it("returns v0.10.0 and v0.11.0 for v0.9.0", () => {
+    assert.equal(getTransforms([0, 9, 0]).length, 2);
   });
-  it("returns nothing for v0.10.0", () => {
-    assert.equal(getTransforms([0, 10, 0]).length, 0);
+  it("returns only v0.11.0 for v0.10.0", () => {
+    assert.equal(getTransforms([0, 10, 0]).length, 1);
+  });
+  it("returns nothing for v0.11.0", () => {
+    assert.equal(getTransforms([0, 11, 0]).length, 0);
   });
 });
 
@@ -139,14 +143,54 @@ describe("v0.10.0 transform", () => {
   });
 });
 
+describe("v0.11.0 transform", () => {
+  it("converts jobs.x path to $.jobs.x", () => {
+    const input = {
+      $schema: schemaUrl("0.10.0"),
+      services: [{ serviceTag: "svc", promotionType: "securePipelines", checks: [{ checkTypes: ["unit"], phase: "pre-merge", provider: "GitHub", config: { file: "a.yml", path: "jobs.run-tests" } }] }],
+    };
+    const result = v0110(input);
+    assert.equal(result.services[0].checks[0].config.path, "$.jobs.run-tests");
+    assert.equal(result.$schema, schemaUrl("0.11.0"));
+  });
+
+  it("leaves already-prefixed paths unchanged", () => {
+    const input = {
+      $schema: schemaUrl("0.10.0"),
+      services: [{ serviceTag: "svc", promotionType: "securePipelines", checks: [{ checkTypes: ["unit"], phase: "pre-merge", provider: "GitHub", config: { file: "a.yml", path: "$.jobs.foo" } }] }],
+    };
+    assert.equal(v0110(input).services[0].checks[0].config.path, "$.jobs.foo");
+  });
+
+  it("removes config.name and config.jobName", () => {
+    const input = {
+      $schema: schemaUrl("0.10.0"),
+      services: [{ serviceTag: "svc", promotionType: "securePipelines", checks: [{ checkTypes: ["unit"], phase: "pre-merge", provider: "GitHub", config: { file: "a.yml", path: "jobs.test", name: "Run tests", jobName: "test" } }] }],
+    };
+    const result = v0110(input);
+    assert.equal(result.services[0].checks[0].config.name, undefined);
+    assert.equal(result.services[0].checks[0].config.jobName, undefined);
+  });
+
+  it("handles checks without path", () => {
+    const input = {
+      $schema: schemaUrl("0.10.0"),
+      services: [{ serviceTag: "svc", promotionType: "securePipelines", checks: [{ checkTypes: ["unit"], phase: "pre-merge", provider: "Terraform", config: { file: "main.tf" } }] }],
+    };
+    const result = v0110(input);
+    assert.equal(result.services[0].checks[0].config.path, undefined);
+    assert.equal(result.services[0].checks[0].config.file, "main.tf");
+  });
+});
+
 describe("full pipeline", () => {
-  it("upgrades v0.1.0 manifest to v0.9.0", () => {
+  it("upgrades v0.1.0 manifest to v0.11.0", () => {
     const input = {
       $schema: "https://raw.githubusercontent.com/govuk-one-login/quality-gates/refs/tags/v0.1.0/schemas/schema.json",
       services: [{
         "service-tag": "example",
         "quality-gates": [
-          { "check-types": ["integration"], phase: "pre-merge", provider: "Stack Orchestrator", config: { file: "test.yml" } },
+          { "check-types": ["integration"], phase: "pre-merge", provider: "Stack Orchestrator", config: { file: "test.yml", path: "jobs.build", name: "Build" } },
         ],
       }],
     };
@@ -157,10 +201,12 @@ describe("full pipeline", () => {
       result = transform(result);
     }
 
-    assert.equal(result.$schema, schemaUrl("0.10.0"));
+    assert.equal(result.$schema, schemaUrl("0.11.0"));
     assert.equal(result.services[0].serviceTag, "example");
     assert.equal(result.services[0].promotionType, "securePipelines");
     assert.deepEqual(result.services[0].checks[0].checkTypes, ["integration"]);
-    assert.deepEqual(result.services[0].checks[0].provider, "Stack Orchestration Tool")
+    assert.deepEqual(result.services[0].checks[0].provider, "Stack Orchestration Tool");
+    assert.equal(result.services[0].checks[0].config.path, "$.jobs.build");
+    assert.equal(result.services[0].checks[0].config.name, undefined);
   });
 });

--- a/cli/upgrades/v0.11.0.js
+++ b/cli/upgrades/v0.11.0.js
@@ -1,0 +1,17 @@
+import { schemaUrl } from "./index.js";
+
+export function transform(manifest) {
+  return {
+    $schema: schemaUrl("0.11.0"),
+    services: (manifest.services || []).map((service) => ({
+      ...service,
+      checks: (service.checks || []).map(({ config, ...rest }) => {
+        const { name, jobName, ...cleanConfig } = config;
+        if (cleanConfig.path && !cleanConfig.path.startsWith("$")) {
+          cleanConfig.path = `$.${cleanConfig.path}`;
+        }
+        return { ...rest, config: cleanConfig };
+      }),
+    })),
+  };
+}

--- a/cli/utils/jsonpath.js
+++ b/cli/utils/jsonpath.js
@@ -1,0 +1,21 @@
+const JOB_DOT = /^\$\.jobs\.([a-zA-Z_][\w-]*)$/;
+const JOB_BRACKET = /^\$\.jobs\['([^']+)'\]$/;
+const STEP_DOT = /^\$\.jobs\.([a-zA-Z_][\w-]*)\.steps\[\?@\.(id|name)=='(.+)'\]$/;
+const STEP_BRACKET = /^\$\.jobs\['([^']+)'\]\.steps\[\?@\.(id|name)=='(.+)'\]$/;
+
+export function parseCheckPath(path) {
+  if (!path) return { valid: false };
+
+  let m;
+  if ((m = path.match(STEP_DOT)) || (m = path.match(STEP_BRACKET))) {
+    return { valid: true, job: m[1], step: { by: m[2], value: m[3] } };
+  }
+  if ((m = path.match(JOB_DOT)) || (m = path.match(JOB_BRACKET))) {
+    return { valid: true, job: m[1], step: null };
+  }
+  return { valid: false };
+}
+
+export function isValidJsonPath(path) {
+  return typeof path === "string" && path.startsWith("$");
+}

--- a/cli/utils/jsonpath.test.js
+++ b/cli/utils/jsonpath.test.js
@@ -1,0 +1,69 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseCheckPath, isValidJsonPath } from "./jsonpath.js";
+
+describe("parseCheckPath", () => {
+  it("parses dot-notation job path", () => {
+    assert.deepEqual(parseCheckPath("$.jobs.build"), { valid: true, job: "build", step: null });
+  });
+
+  it("parses bracket-notation job path", () => {
+    assert.deepEqual(parseCheckPath("$.jobs['run-tests']"), { valid: true, job: "run-tests", step: null });
+  });
+
+  it("parses dot-notation job with step filter by name", () => {
+    assert.deepEqual(parseCheckPath("$.jobs.build.steps[?@.name=='Run tests']"), {
+      valid: true, job: "build", step: { by: "name", value: "Run tests" },
+    });
+  });
+
+  it("parses dot-notation job with step filter by id", () => {
+    assert.deepEqual(parseCheckPath("$.jobs.build.steps[?@.id=='run-tests']"), {
+      valid: true, job: "build", step: { by: "id", value: "run-tests" },
+    });
+  });
+
+  it("parses bracket-notation job with step filter", () => {
+    assert.deepEqual(parseCheckPath("$.jobs['my-job'].steps[?@.name=='Run tests']"), {
+      valid: true, job: "my-job", step: { by: "name", value: "Run tests" },
+    });
+  });
+
+  it("handles special characters in step names", () => {
+    assert.deepEqual(parseCheckPath("$.jobs.pre-commit.steps[?@.name=='✅ Run Pre-commit Hooks']"), {
+      valid: true, job: "pre-commit", step: { by: "name", value: "✅ Run Pre-commit Hooks" },
+    });
+  });
+
+  it("returns invalid for paths without $ prefix", () => {
+    assert.deepEqual(parseCheckPath("jobs.build"), { valid: false });
+  });
+
+  it("returns invalid for null/undefined", () => {
+    assert.deepEqual(parseCheckPath(null), { valid: false });
+    assert.deepEqual(parseCheckPath(undefined), { valid: false });
+  });
+
+  it("returns invalid for non-GitHub style paths", () => {
+    assert.deepEqual(parseCheckPath("$.module.x.parameters.Y"), { valid: false });
+    assert.deepEqual(parseCheckPath("$[?@.ParameterKey=='X']"), { valid: false });
+  });
+});
+
+describe("isValidJsonPath", () => {
+  it("returns true for paths starting with $", () => {
+    assert.equal(isValidJsonPath("$.jobs.build"), true);
+    assert.equal(isValidJsonPath("$.module.x.y"), true);
+    assert.equal(isValidJsonPath("$[?@.Key=='X']"), true);
+  });
+
+  it("returns false for non-JSONPath strings", () => {
+    assert.equal(isValidJsonPath("jobs.build"), false);
+    assert.equal(isValidJsonPath(""), false);
+  });
+
+  it("returns false for non-strings", () => {
+    assert.equal(isValidJsonPath(null), false);
+    assert.equal(isValidJsonPath(undefined), false);
+  });
+});

--- a/cli/validators/mismatched-jobs.js
+++ b/cli/validators/mismatched-jobs.js
@@ -1,31 +1,46 @@
+import { parseCheckPath } from "../utils/jsonpath.js";
+
 export function findMismatchedJobs(data) {
   const workflowJobs = new Map(
-    data.workflows.map(({ name, jobs }) => [name, Object.keys(jobs)])
+    data.workflows.map(({ name, jobs }) => [name, jobs])
   );
 
   return data.manifest.services.flatMap((s) => {
     const service = s.serviceTag || s["service-tag"];
     const checks = s.checks || s.qualityGates || s["quality-gates"] || [];
-    return checks
-      .filter((g) => {
-        const jobKey = g.config.path?.split(".")[1];
-        const filename = g.config.file.replace(".github/workflows/", "");
-        if (!jobKey) return false;
-        if (!workflowJobs.has(filename)) return false;
-        return !workflowJobs.get(filename).includes(jobKey);
-      })
-      .map((g) => {
-        const filename = g.config.file.replace(".github/workflows/", "");
-        return {
-          type: "mismatched-job",
-          service,
-          message: `Job not found: ${g.config.path}`,
-          details: {
-            path: g.config.path,
-            workflow: filename,
-            available: workflowJobs.get(filename) || [],
-          },
-        };
-      });
+    return checks.flatMap((g) => {
+      if (g.provider !== "GitHub") return [];
+      if (!g.config.path) return [];
+
+      const filename = g.config.file.replace(".github/workflows/", "");
+      if (!workflowJobs.has(filename)) return [];
+
+      const parsed = parseCheckPath(g.config.path);
+      if (!parsed.valid) {
+        return [{ type: "invalid-path-syntax", service, message: `Invalid JSONPath syntax: ${g.config.path}`, details: { path: g.config.path } }];
+      }
+
+      const jobs = workflowJobs.get(filename);
+      const jobKeys = Object.keys(jobs);
+      if (!jobKeys.includes(parsed.job)) {
+        return [{ type: "mismatched-job", service, message: `Job not found: ${g.config.path}`, details: { path: g.config.path, workflow: filename, available: jobKeys } }];
+      }
+
+      if (parsed.step) {
+        const steps = jobs[parsed.job].steps || [];
+        const match = steps.some((st) => st[parsed.step.by] === parsed.step.value);
+        if (!match) {
+          const available = steps.flatMap((st) => {
+            const items = [];
+            if (st.id) items.push(`id:${st.id}`);
+            if (st.name) items.push(`name:${st.name}`);
+            return items;
+          });
+          return [{ type: "mismatched-step", service, message: `Step not found: ${g.config.path}`, details: { path: g.config.path, job: parsed.job, step: parsed.step, workflow: filename, available } }];
+        }
+      }
+
+      return [];
+    });
   });
 }

--- a/cli/validators/mismatched-jobs.test.js
+++ b/cli/validators/mismatched-jobs.test.js
@@ -4,7 +4,7 @@ import { findMismatchedJobs } from "./mismatched-jobs.js";
 
 const makeData = (checks, jobs) => ({
   manifest: {
-    services: [{ serviceTag: "my-service", checks: checks }],
+    services: [{ serviceTag: "my-service", checks }],
   },
   workflows: [{ name: "ci.yml", jobs }],
 });
@@ -12,49 +12,107 @@ const makeData = (checks, jobs) => ({
 describe("findMismatchedJobs", () => {
   it("returns empty array when all jobs exist", () => {
     const data = makeData(
-      [{ config: { file: ".github/workflows/ci.yml", path: "jobs.build" } }],
-      { build: {} }
+      [{ provider: "GitHub", config: { file: ".github/workflows/ci.yml", path: "$.jobs.build" } }],
+      { build: { steps: [] } }
     );
     assert.deepEqual(findMismatchedJobs(data), []);
   });
 
   it("returns error for invalid job path", () => {
     const data = makeData(
-      [{ config: { file: ".github/workflows/ci.yml", path: "jobs.deploy" } }],
-      { build: {}, test: {} }
+      [{ provider: "GitHub", config: { file: ".github/workflows/ci.yml", path: "$.jobs.deploy" } }],
+      { build: { steps: [] }, test: { steps: [] } }
     );
     const errors = findMismatchedJobs(data);
     assert.equal(errors.length, 1);
     assert.equal(errors[0].type, "mismatched-job");
-    assert.equal(errors[0].details.path, "jobs.deploy");
-    assert.equal(errors[0].details.workflow, "ci.yml");
+    assert.equal(errors[0].details.path, "$.jobs.deploy");
     assert.deepEqual(errors[0].details.available, ["build", "test"]);
   });
 
   it("returns multiple errors for multiple invalid paths", () => {
     const data = makeData(
       [
-        { config: { file: ".github/workflows/ci.yml", path: "jobs.foo" } },
-        { config: { file: ".github/workflows/ci.yml", path: "jobs.bar" } },
+        { provider: "GitHub", config: { file: ".github/workflows/ci.yml", path: "$.jobs.foo" } },
+        { provider: "GitHub", config: { file: ".github/workflows/ci.yml", path: "$.jobs.bar" } },
       ],
-      { build: {} }
+      { build: { steps: [] } }
     );
     assert.equal(findMismatchedJobs(data).length, 2);
   });
 
   it("skips checks whose workflow file does not exist", () => {
     const data = makeData(
-      [{ config: { file: ".github/workflows/missing.yml", path: "jobs.x" } }],
-      { build: {} }
+      [{ provider: "GitHub", config: { file: ".github/workflows/missing.yml", path: "$.jobs.x" } }],
+      { build: { steps: [] } }
     );
     assert.deepEqual(findMismatchedJobs(data), []);
   });
 
   it("skips checks with no path property", () => {
     const data = makeData(
-      [{ config: { file: ".github/workflows/ci.yml" } }],
-      { build: {} }
+      [{ provider: "GitHub", config: { file: ".github/workflows/ci.yml" } }],
+      { build: { steps: [] } }
     );
     assert.deepEqual(findMismatchedJobs(data), []);
+  });
+
+  it("skips non-GitHub provider checks", () => {
+    const data = makeData(
+      [{ provider: "Terraform", config: { file: "terraform/main.tf", path: "$.module.x" } }],
+      { build: { steps: [] } }
+    );
+    assert.deepEqual(findMismatchedJobs(data), []);
+  });
+
+  it("returns error for invalid JSONPath syntax", () => {
+    const data = makeData(
+      [{ provider: "GitHub", config: { file: ".github/workflows/ci.yml", path: "$.invalid[syntax" } }],
+      { build: { steps: [] } }
+    );
+    const errors = findMismatchedJobs(data);
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].type, "invalid-path-syntax");
+  });
+
+  it("validates step by name - found", () => {
+    const data = makeData(
+      [{ provider: "GitHub", config: { file: ".github/workflows/ci.yml", path: "$.jobs.build.steps[?@.name=='Run tests']" } }],
+      { build: { steps: [{ name: "Checkout" }, { name: "Run tests" }] } }
+    );
+    assert.deepEqual(findMismatchedJobs(data), []);
+  });
+
+  it("validates step by name - not found", () => {
+    const data = makeData(
+      [{ provider: "GitHub", config: { file: ".github/workflows/ci.yml", path: "$.jobs.build.steps[?@.name=='Run tests']" } }],
+      { build: { steps: [{ name: "Checkout" }, { name: "Lint" }] } }
+    );
+    const errors = findMismatchedJobs(data);
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].type, "mismatched-step");
+    assert.equal(errors[0].details.job, "build");
+    assert.ok(errors[0].details.available.includes("name:Checkout"));
+    assert.ok(errors[0].details.available.includes("name:Lint"));
+  });
+
+  it("validates step by id - found", () => {
+    const data = makeData(
+      [{ provider: "GitHub", config: { file: ".github/workflows/ci.yml", path: "$.jobs.build.steps[?@.id=='run-tests']" } }],
+      { build: { steps: [{ id: "checkout" }, { id: "run-tests", name: "Run tests" }] } }
+    );
+    assert.deepEqual(findMismatchedJobs(data), []);
+  });
+
+  it("validates step by id - not found", () => {
+    const data = makeData(
+      [{ provider: "GitHub", config: { file: ".github/workflows/ci.yml", path: "$.jobs.build.steps[?@.id=='missing']" } }],
+      { build: { steps: [{ id: "checkout" }, { id: "run-tests" }] } }
+    );
+    const errors = findMismatchedJobs(data);
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].type, "mismatched-step");
+    assert.ok(errors[0].details.available.includes("id:checkout"));
+    assert.ok(errors[0].details.available.includes("id:run-tests"));
   });
 });

--- a/cli/validators/missing-workflows.js
+++ b/cli/validators/missing-workflows.js
@@ -6,6 +6,7 @@ export function findMissingWorkflows(data) {
     const service = s.serviceTag || s["service-tag"];
     const checks = s.checks || s.qualityGates || s["quality-gates"] || [];
     return checks
+      .filter((g) => g.config.file.startsWith(".github/workflows/"))
       .filter((g) => !workflowNames.has(g.config.file.replace(".github/workflows/", "")))
       .map((g) => ({
         type: "missing-workflow",

--- a/cli/validators/missing-workflows.test.js
+++ b/cli/validators/missing-workflows.test.js
@@ -49,4 +49,20 @@ describe("findMissingWorkflows", () => {
     };
     assert.equal(findMissingWorkflows(data).length, 2);
   });
+
+  it("skips non-GitHub workflow file paths", () => {
+    const data = {
+      manifest: {
+        services: [{
+          serviceTag: "svc",
+          checks: [
+            { config: { file: "terraform/main.tf" } },
+            { config: { file: "ci/stack-orchestration/parameters.json" } },
+          ],
+        }],
+      },
+      workflows: [{ name: "ci.yml", jobs: {} }],
+    };
+    assert.deepEqual(findMissingWorkflows(data), []);
+  });
 });

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,9 +55,14 @@ These various usages are then annotated using the schema file to create a repres
 - Validation happens at authoring time (editor support) and in CI
 - Analysis and visualisation are separate concerns
 
-### JMESPath for config paths
+### JSONPath for config paths
 
-The `config.path` field uses JMESPath-compatible expressions to identify specific nodes within workflow files (e.g., `jobs.run-tests`). This provides a standard way to reference nested YAML/JSON structures without coupling to a specific CI platform's object model.
+The `config.path` field uses JSONPath (RFC 9535) expressions to identify specific nodes within workflow and configuration files (e.g., `$.jobs.run-tests`). This provides a standardised way to reference nested YAML/JSON structures without coupling to a specific CI platform's object model. JSONPath was chosen over alternatives (JMESPath, jq, JSON Pointer) because:
+
+- It is an IETF standard (RFC 9535, February 2024)
+- It supports filter expressions for addressing array elements by property (e.g., steps by name or id)
+- Hyphenated identifiers work in dot notation without quoting
+- The `$` root prefix makes expressions unambiguous and regex-validatable
 
 ### Dogfooding
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -130,4 +130,18 @@ Valid phases depend on the service's `promotionType`:
 | Field  | Required | Description                                       |
 |--------|----------|---------------------------------------------------|
 | `file` | Yes      | Path to the workflow/config file                  |
-| `path` | No       | JMESPath expression identifying the relevant node |
+| `path` | No       | JSONPath (RFC 9535) expression identifying the relevant node |
+
+#### Provider path examples
+
+| Provider | File format | Example `path` |
+|----------|-------------|-----------------|
+| GitHub | YAML workflow | `$.jobs.build.steps[?@.name=='Run tests']` |
+| Terraform | HCL (`.tf`) | `$.module.my-pipeline.parameters.TestImageRepositoryUri` |
+| Stack Orchestration Tool | JSON parameters | `$[?@.ParameterKey=='LambdaCanaryDeployment']` |
+| CloudFormation | YAML/JSON template | `$.Resources.MyFunction.Properties.Handler` |
+
+Notes:
+- The `path` field must start with `$` (the JSONPath root identifier)
+- The `file` field must not contain `:` (external cross-repo references are not supported)
+- For GitHub providers, `path` typically references jobs and steps: `$.jobs.<name>` or `$.jobs.<name>.steps[?@.name=='<step>']`

--- a/examples/github-gitflow.json
+++ b/examples/github-gitflow.json
@@ -5,12 +5,12 @@
       "promotionType": "gitFlow",
       "checks": [
         {
-          "checkTypes": ["unit"],
+          "checkTypes": ["code style and linting"],
           "provider": "GitHub",
           "phase": "pre-develop",
           "config": {
             "file": ".github/workflows/lint.yaml",
-            "name": "Lint"
+            "path": "$.jobs.lint"
           }
         },
         {
@@ -18,35 +18,35 @@
           "provider": "GitHub",
           "phase": "develop",
           "config": {
-            "file": ".github/workflows/lint.yaml",
-            "name": "Lint"
+            "file": ".github/workflows/tests.yaml",
+            "path": "$.jobs.unit"
           }
         },
         {
-          "checkTypes": ["unit"],
+          "checkTypes": ["integration"],
           "provider": "GitHub",
           "phase": "pre-release",
           "config": {
-            "file": ".github/workflows/lint.yaml",
-            "name": "Lint"
+            "file": ".github/workflows/integration.yaml",
+            "path": "$.jobs.integration.steps[?@.name=='Run integration tests']"
           }
         },
         {
-          "checkTypes": ["unit"],
+          "checkTypes": ["e2e"],
           "provider": "GitHub",
-          "phase": "pre-release",
+          "phase": "release",
           "config": {
-            "file": ".github/workflows/lint.yaml",
-            "name": "Lint"
+            "file": ".github/workflows/e2e.yaml",
+            "path": "$.jobs.e2e"
           }
         },
         {
-          "checkTypes": ["unit"],
+          "checkTypes": ["smoke"],
           "provider": "GitHub",
           "phase": "main",
           "config": {
-            "file": ".github/workflows/lint.yaml",
-            "name": "Lint"
+            "file": ".github/workflows/smoke.yaml",
+            "path": "$.jobs.smoke"
           }
         }
       ]

--- a/examples/github-librarysdk.json
+++ b/examples/github-librarysdk.json
@@ -9,8 +9,17 @@
           "provider": "GitHub",
           "phase": "pre-merge",
           "config": {
-            "file": ".github/workflows/check-code-quality.yaml",
-            "name": "Run pre-commit"
+            "file": ".github/workflows/tests.yaml",
+            "path": "$.jobs.unit"
+          }
+        },
+        {
+          "checkTypes": ["code style and linting"],
+          "provider": "GitHub",
+          "phase": "pre-merge",
+          "config": {
+            "file": ".github/workflows/quality.yaml",
+            "path": "$.jobs.lint.steps[?@.name=='Run linter']"
           }
         },
         {
@@ -18,17 +27,8 @@
           "provider": "GitHub",
           "phase": "pre-release",
           "config": {
-            "file": "",
-            "name": "Run Gitlint"
-          }
-        },
-        {
-          "checkTypes": ["unit"],
-          "provider": "GitHub",
-          "phase": "pre-merge",
-          "config": {
-            "file": "",
-            "name": "Run Checkov"
+            "file": ".github/workflows/release.yaml",
+            "path": "$.jobs.test"
           }
         }
       ]

--- a/examples/github-trunk.json
+++ b/examples/github-trunk.json
@@ -9,26 +9,26 @@
           "provider": "GitHub",
           "phase": "pre-merge",
           "config": {
-            "file": ".github/workflows/check-code-quality.yaml",
-            "name": "Run pre-commit"
+            "file": ".github/workflows/tests.yaml",
+            "path": "$.jobs.unit"
           }
         },
         {
-          "checkTypes": ["unit"],
+          "checkTypes": ["code style and linting"],
           "provider": "GitHub",
           "phase": "pre-merge",
           "config": {
-            "file": "",
-            "name": "Run Gitlint"
+            "file": ".github/workflows/quality.yaml",
+            "path": "$.jobs.pre-commit"
           }
         },
         {
-          "checkTypes": ["unit"],
+          "checkTypes": ["vulnerability detection"],
           "provider": "GitHub",
           "phase": "pre-merge",
           "config": {
-            "file": "",
-            "name": "Run Checkov"
+            "file": ".github/workflows/quality.yaml",
+            "path": "$.jobs.codeql"
           }
         }
       ]

--- a/examples/github.json
+++ b/examples/github.json
@@ -10,7 +10,7 @@
           "phase": "pre-merge",
           "config": {
             "file": ".github/workflows/check-code-quality.yaml",
-            "name": "Run pre-commit"
+            "path": "$.jobs.pre-commit"
           }
         },
         {
@@ -18,8 +18,8 @@
           "provider": "GitHub",
           "phase": "pre-merge",
           "config": {
-            "file": "",
-            "name": "Run Gitlint"
+            "file": ".github/workflows/check-code-quality.yaml",
+            "path": "$.jobs.gitlint"
           }
         },
         {
@@ -27,8 +27,8 @@
           "provider": "GitHub",
           "phase": "pre-merge",
           "config": {
-            "file": "",
-            "name": "Run Checkov"
+            "file": ".github/workflows/check-code-quality.yaml",
+            "path": "$.jobs.checkov"
           }
         }
       ]

--- a/quality-gate.manifest.json
+++ b/quality-gate.manifest.json
@@ -11,7 +11,7 @@
           "provider": "GitHub",
           "config": {
             "file": ".github/workflows/schema.yml",
-            "path": "jobs.run-tests"
+            "path": "$.jobs.run-tests"
           }
         },
         {
@@ -20,7 +20,7 @@
           "provider": "GitHub",
           "config": {
             "file": ".github/workflows/visualiser.yml",
-            "path": "jobs.run-tests"
+            "path": "$.jobs.run-tests"
           }
         },
         {
@@ -29,7 +29,7 @@
           "provider": "GitHub",
           "config": {
             "file": ".github/workflows/quality.yml",
-            "path": "jobs.codeql"
+            "path": "$.jobs.codeql"
           }
         },
         {
@@ -38,7 +38,7 @@
           "provider": "GitHub",
           "config": {
             "file": ".github/workflows/quality.yml",
-            "path": "jobs.pre-commit"
+            "path": "$.jobs.pre-commit"
           }
         }
       ]

--- a/schemas/schema.json
+++ b/schemas/schema.json
@@ -15,7 +15,7 @@
               "phase": "pre-merge",
               "config": {
                 "file": ".github/workflows/check-code-quality.yaml",
-                "name": "Run pre-commit"
+                "path": "$.jobs.pre-commit"
               }
             }
           ]
@@ -62,11 +62,13 @@
       "type": "object",
       "properties": {
         "file": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[^:]*$"
         },
         "path": {
-          "description": "JMESPath compatible expression to identify relevant property or node",
-          "type": "string"
+          "description": "JSONPath (RFC 9535) expression identifying the relevant node in the file",
+          "type": "string",
+          "pattern": "^\\$"
         }
       },
       "required": [

--- a/test/check-types.json
+++ b/test/check-types.json
@@ -17,8 +17,7 @@
                 "phase": "pre-merge",
                 "config": {
                   "file": ".github/workflows/tests.yaml",
-                  "path": "jobs.unit",
-                  "jobName": "Run unit tests"
+                  "path": "$.jobs.unit"
                 }
               }
             ]
@@ -41,8 +40,7 @@
                 "phase": "pre-merge",
                 "config": {
                   "file": ".github/workflows/tests.yaml",
-                  "path": "jobs.unit",
-                  "jobName": "Run unit tests"
+                  "path": "$.jobs.unit"
                 }
               }
             ]
@@ -65,8 +63,7 @@
                 "phase": "pre-merge",
                 "config": {
                   "file": ".github/workflows/tests.yaml",
-                  "path": "jobs.unit",
-                  "jobName": "Run unit tests"
+                  "path": "$.jobs.unit"
                 }
               }
             ]
@@ -89,8 +86,7 @@
                 "phase": "pre-merge",
                 "config": {
                   "file": ".github/workflows/tests.yaml",
-                  "path": "jobs.unit",
-                  "jobName": "Run unit tests"
+                  "path": "$.jobs.unit"
                 }
               }
             ]
@@ -113,8 +109,7 @@
                 "phase": "pre-merge",
                 "config": {
                   "file": ".github/workflows/tests.yaml",
-                  "path": "jobs.unit",
-                  "jobName": "Run unit tests"
+                  "path": "$.jobs.unit"
                 }
               }
             ]

--- a/test/gitflow.json
+++ b/test/gitflow.json
@@ -17,8 +17,7 @@
                 "phase": "pre-develop",
                 "config": {
                   "file": ".github/workflows/tests.yaml",
-                  "path": "jobs.unit",
-                  "jobName": "Run unit tests"
+                  "path": "$.jobs.unit"
                 }
               },
               {
@@ -27,8 +26,7 @@
                 "phase": "develop",
                 "config": {
                   "file": ".github/workflows/tests.yaml",
-                  "path": "jobs.unit",
-                  "jobName": "Run unit tests"
+                  "path": "$.jobs.unit"
                 }
               },
               {
@@ -37,8 +35,7 @@
                 "phase": "pre-release",
                 "config": {
                   "file": ".github/workflows/tests.yaml",
-                  "path": "jobs.unit",
-                  "jobName": "Run unit tests"
+                  "path": "$.jobs.unit"
                 }
               },
               {
@@ -47,8 +44,7 @@
                 "phase": "release",
                 "config": {
                   "file": ".github/workflows/tests.yaml",
-                  "path": "jobs.unit",
-                  "jobName": "Run unit tests"
+                  "path": "$.jobs.unit"
                 }
               },
               {
@@ -57,8 +53,7 @@
                 "phase": "main",
                 "config": {
                   "file": ".github/workflows/tests.yaml",
-                  "path": "jobs.unit",
-                  "jobName": "Run unit tests"
+                  "path": "$.jobs.unit"
                 }
               }
             ]

--- a/test/jsonpath.json
+++ b/test/jsonpath.json
@@ -1,114 +1,22 @@
 {
   "target": "../schemas/schema.json",
-  "$comment": "promotionType conditional phase validation tests",
+  "$comment": "JSONPath config.path validation tests",
   "tests": [
     {
-      "description": "securePipelines with valid phase staging",
+      "description": "Valid JSONPath: $.jobs.test",
       "valid": true,
       "data": {
         "services": [
           {
             "serviceTag": "service",
             "promotionType": "securePipelines",
-            "checks": [
-              {
-                "checkTypes": ["unit"],
-                "provider": "GitHub",
-                "phase": "staging",
-                "config": {
-                  "file": ".github/workflows/test.yaml",
-                  "path": "$.jobs.test"
-                }
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "description": "securePipelines with invalid phase develop",
-      "valid": false,
-      "data": {
-        "services": [
-          {
-            "serviceTag": "service",
-            "promotionType": "securePipelines",
-            "checks": [
-              {
-                "checkTypes": ["unit"],
-                "provider": "GitHub",
-                "phase": "develop",
-                "config": {
-                  "file": ".github/workflows/test.yaml",
-                  "path": "$.jobs.test"
-                }
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "description": "gitFlow with valid phase develop",
-      "valid": true,
-      "data": {
-        "services": [
-          {
-            "serviceTag": "service",
-            "promotionType": "gitFlow",
-            "checks": [
-              {
-                "checkTypes": ["unit"],
-                "provider": "GitHub",
-                "phase": "develop",
-                "config": {
-                  "file": ".github/workflows/test.yaml",
-                  "path": "$.jobs.test"
-                }
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "description": "gitFlow with invalid phase staging",
-      "valid": false,
-      "data": {
-        "services": [
-          {
-            "serviceTag": "service",
-            "promotionType": "gitFlow",
-            "checks": [
-              {
-                "checkTypes": ["unit"],
-                "provider": "GitHub",
-                "phase": "staging",
-                "config": {
-                  "file": ".github/workflows/test.yaml",
-                  "path": "$.jobs.test"
-                }
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "description": "library with valid phase pre-merge",
-      "valid": true,
-      "data": {
-        "services": [
-          {
-            "serviceTag": "service",
-            "promotionType": "library",
             "checks": [
               {
                 "checkTypes": ["unit"],
                 "provider": "GitHub",
                 "phase": "pre-merge",
                 "config": {
-                  "file": ".github/workflows/test.yaml",
+                  "file": ".github/workflows/test.yml",
                   "path": "$.jobs.test"
                 }
               }
@@ -118,21 +26,67 @@
       }
     },
     {
-      "description": "library with invalid phase build",
-      "valid": false,
+      "description": "Valid JSONPath: bracket notation $.jobs['my-job']",
+      "valid": true,
       "data": {
         "services": [
           {
             "serviceTag": "service",
-            "promotionType": "library",
+            "promotionType": "securePipelines",
             "checks": [
               {
                 "checkTypes": ["unit"],
                 "provider": "GitHub",
+                "phase": "pre-merge",
+                "config": {
+                  "file": ".github/workflows/test.yml",
+                  "path": "$.jobs['my-job']"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "description": "Valid JSONPath: step filter by name",
+      "valid": true,
+      "data": {
+        "services": [
+          {
+            "serviceTag": "service",
+            "promotionType": "securePipelines",
+            "checks": [
+              {
+                "checkTypes": ["unit"],
+                "provider": "GitHub",
+                "phase": "pre-merge",
+                "config": {
+                  "file": ".github/workflows/test.yml",
+                  "path": "$.jobs.build.steps[?@.name=='Run tests']"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "description": "Valid JSONPath: Stack Orchestration Tool filter",
+      "valid": true,
+      "data": {
+        "services": [
+          {
+            "serviceTag": "service",
+            "promotionType": "securePipelines",
+            "checks": [
+              {
+                "checkTypes": ["integration"],
+                "provider": "Stack Orchestration Tool",
                 "phase": "build",
                 "config": {
-                  "file": ".github/workflows/test.yaml",
-                  "path": "$.jobs.test"
+                  "file": "ci/stack-orchestration/parameters.json",
+                  "path": "$[?@.ParameterKey=='X']"
                 }
               }
             ]
@@ -141,20 +95,21 @@
       }
     },
     {
-      "description": "service without promotionType is invalid",
+      "description": "Invalid: path without $ prefix",
       "valid": false,
       "data": {
         "services": [
           {
             "serviceTag": "service",
+            "promotionType": "securePipelines",
             "checks": [
               {
                 "checkTypes": ["unit"],
                 "provider": "GitHub",
                 "phase": "pre-merge",
                 "config": {
-                  "file": ".github/workflows/test.yaml",
-                  "path": "$.jobs.test"
+                  "file": ".github/workflows/test.yml",
+                  "path": "jobs.test"
                 }
               }
             ]
@@ -163,21 +118,64 @@
       }
     },
     {
-      "description": "service with unknown promotionType is invalid",
+      "description": "Invalid: file with colon (external reference)",
       "valid": false,
       "data": {
         "services": [
           {
             "serviceTag": "service",
-            "promotionType": "unknown",
+            "promotionType": "securePipelines",
+            "checks": [
+              {
+                "checkTypes": ["unit"],
+                "provider": "Terraform",
+                "phase": "build",
+                "config": {
+                  "file": "other-repo:terraform/main.tf"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "description": "Valid: Terraform check without path",
+      "valid": true,
+      "data": {
+        "services": [
+          {
+            "serviceTag": "service",
+            "promotionType": "securePipelines",
+            "checks": [
+              {
+                "checkTypes": ["integration"],
+                "provider": "Terraform",
+                "phase": "build",
+                "config": {
+                  "file": "terraform/main.tf"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "description": "Valid: GitHub check without path",
+      "valid": true,
+      "data": {
+        "services": [
+          {
+            "serviceTag": "service",
+            "promotionType": "securePipelines",
             "checks": [
               {
                 "checkTypes": ["unit"],
                 "provider": "GitHub",
                 "phase": "pre-merge",
                 "config": {
-                  "file": ".github/workflows/test.yaml",
-                  "path": "$.jobs.test"
+                  "file": ".github/workflows/test.yml"
                 }
               }
             ]

--- a/test/librarysdk.json
+++ b/test/librarysdk.json
@@ -8,7 +8,7 @@
       "data": {
         "services": [
           {
-            "serviceTag": "generic-library",
+            "serviceTag": "generic-service",
             "promotionType": "library",
             "checks": [
               {
@@ -17,8 +17,7 @@
                 "phase": "pre-merge",
                 "config": {
                   "file": ".github/workflows/tests.yaml",
-                  "path": "jobs.unit",
-                  "jobName": "Run unit tests"
+                  "path": "$.jobs.unit"
                 }
               },
               {
@@ -27,8 +26,7 @@
                 "phase": "pre-release",
                 "config": {
                   "file": ".github/workflows/tests.yaml",
-                  "path": "jobs.unit",
-                  "jobName": "Run unit tests"
+                  "path": "$.jobs.unit"
                 }
               }
             ]

--- a/test/provider.json
+++ b/test/provider.json
@@ -15,7 +15,10 @@
                 "checkTypes": ["unit"],
                 "provider": "GitHub",
                 "phase": "pre-merge",
-                "config": { "file": "test.yaml" }
+                "config": {
+                  "file": ".github/workflows/test.yaml",
+                  "path": "$.jobs.test"
+                }
               }
             ]
           }
@@ -35,7 +38,9 @@
                 "checkTypes": ["unit"],
                 "provider": "Terraform",
                 "phase": "pre-merge",
-                "config": { "file": "test.yaml" }
+                "config": {
+                  "file": "terraform/main.tf"
+                }
               }
             ]
           }
@@ -55,7 +60,9 @@
                 "checkTypes": ["unit"],
                 "provider": "CloudFormation",
                 "phase": "pre-merge",
-                "config": { "file": "test.yaml" }
+                "config": {
+                  "file": "template.yaml"
+                }
               }
             ]
           }
@@ -75,7 +82,9 @@
                 "checkTypes": ["unit"],
                 "provider": "Stack Orchestration Tool",
                 "phase": "pre-merge",
-                "config": { "file": "test.yaml" }
+                "config": {
+                  "file": "ci/parameters.json"
+                }
               }
             ]
           }
@@ -95,7 +104,10 @@
                 "checkTypes": ["unit"],
                 "provider": "Jenkins",
                 "phase": "pre-merge",
-                "config": { "file": "test.yaml" }
+                "config": {
+                  "file": ".github/workflows/test.yaml",
+                  "path": "$.jobs.test"
+                }
               }
             ]
           }

--- a/test/trunk.json
+++ b/test/trunk.json
@@ -39,8 +39,7 @@
                 "phase": "pre-merge",
                 "config": {
                   "file": ".github/workflows/tests.yaml",
-                  "path": "jobs.unit",
-                  "jobName": "Run unit tests"
+                  "path": "$.jobs.unit"
                 }
               }
             ]
@@ -63,8 +62,7 @@
                 "phase": "pre-merge",
                 "config": {
                   "file": ".github/workflows/check-code-quality.yaml",
-                  "path": "jobs.pre-commit",
-                  "name": "Run pre-commit"
+                  "path": "$.jobs.pre-commit"
                 }
               }
             ]
@@ -79,8 +77,7 @@
                 "phase": "pre-merge",
                 "config": {
                   "file": ".github/workflows/check-code-quality.yaml",
-                  "path": "jobs.pre-commit",
-                  "name": "Run pre-commit"
+                  "path": "$.jobs.pre-commit"
                 }
               }
             ]
@@ -103,8 +100,7 @@
                 "phase": "pre-merge",
                 "config": {
                   "file": ".github/workflows/check-code-quality.yaml",
-                  "path": "jobs.pre-commit",
-                  "name": "Run pre-commit"
+                  "path": "$.jobs.pre-commit"
                 }
               }
             ]
@@ -119,8 +115,7 @@
                 "phase": "pre-merge",
                 "config": {
                   "file": ".github/workflows/check-code-quality.yaml",
-                  "path": "jobs.pre-commit",
-                  "name": "Run pre-commit"
+                  "path": "$.jobs.pre-commit"
                 }
               }
             ]
@@ -143,8 +138,7 @@
                 "phase": "pre-merge",
                 "config": {
                   "file": ".github/workflows/check-code-quality.yaml",
-                  "path": "jobs.pre-commit",
-                  "name": "Run pre-commit"
+                  "path": "$.jobs.pre-commit"
                 }
               }
             ]


### PR DESCRIPTION
Use JSONPath in schema instead of JMESPath

- JSONPath follows https://datatracker.ietf.org/doc/rfc9535/
- Update CLI tooling to support JSONPath
- Add examples of path for GitHub, Terraform, Stack Orchestration Tool, CloudFormation