### PR TITLE
feat: Add executionMode with automated/manual/outOfBand/notApplicable

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Reference the schema directly in your manifest file:
 
 ```json
 {
-  "$schema": "https://raw.githubusercontent.com/govuk-one-login/quality-gates/refs/tags/v0.0.0/schemas/schema.json",
+  "$schema": "https://raw.githubusercontent.com/govuk-one-login/quality-gates/refs/tags/v0.14.0/schemas/schema.json",
   "services": [
     {
       "product": "my-service",
       "component": "frontend",
       "promotionType": "securePipelines",
-      "checks": [
+      "automated": [
         {
           "checkTypes": ["unit"],
           "phase": "pre-merge",
@@ -29,7 +29,29 @@ Reference the schema directly in your manifest file:
             "path": "$.jobs.test"
           }
         }
-      ]
+      ],
+      "manual": [
+        {
+          "checkTypes": ["accessibility"],
+          "phase": "staging",
+          "details": ["WCAG 2.1 AA audit performed by accessibility team"]
+        }
+      ],
+      "outOfBand": [
+        {
+          "checkTypes": ["smoke"],
+          "phase": "production",
+          "provider": "GitHub",
+          "config": {
+            "file": ".github/workflows/smoke.yml",
+            "path": "$.jobs.smoke"
+          }
+        }
+      ],
+      "notApplicable": {
+        "checkTypes": ["visual regression"],
+        "details": ["No user-facing UI in this component"]
+      }
     }
   ]
 }
@@ -43,6 +65,7 @@ See the [examples/](./examples) directory for complete manifests covering trunk-
 |-----------------------------|------------------------------------------------------------------|
 | [schemas/](./schemas)       | JSON Schema definition for quality gate manifests                |
 | [examples/](./examples)     | Example manifest files for common branching strategies           |
+| [cli/](./cli)               | CLI tool for validation, reference checking, and upgrades        |
 | [visualiser/](./visualiser) | Observable Framework app for viewing and analysing quality gates |
 | [test/](./test)             | Schema validation tests                                          |
 
@@ -78,7 +101,7 @@ See [visualiser/README.md](./visualiser/README.md).
 This schema follows [semantic versioning](https://semver.org/). The schema URL includes a version tag:
 
 ```
-https://raw.githubusercontent.com/govuk-one-login/quality-gates/refs/tags/v0.0.0/schemas/schema.json
+https://raw.githubusercontent.com/govuk-one-login/quality-gates/refs/tags/v0.14.0/schemas/schema.json
 ```
 
 - **Major** — breaking changes to the schema (removed fields, renamed enums)

--- a/cli/commands/upgrade.test.js
+++ b/cli/commands/upgrade.test.js
@@ -34,8 +34,9 @@ describe("upgrade command", () => {
     assert.equal(result.services[0].component, "svc");
     assert.equal(result.services[0].serviceTag, undefined);
     assert.equal(result.services[0].promotionType, "securePipelines");
-    assert.deepEqual(result.services[0].checks[0].checkTypes, ["unit"]);
-    assert.match(result.$schema, /v0\.13\.0/);
+    assert.deepEqual(result.services[0].automated[0].checkTypes, ["unit"]);
+    assert.match(result.$schema, /v0\.14\.0/);
+    assert.equal(result.services[0].checks, undefined);
   });
 
   it("does not write files in dry-run mode", () => {
@@ -64,8 +65,8 @@ describe("upgrade command", () => {
 
   it("skips manifests already at latest version", () => {
     const file = createManifest(TMP, {
-      $schema: "https://raw.githubusercontent.com/govuk-one-login/quality-gates/refs/tags/v0.13.0/schemas/schema.json",
-      services: [{ product: "x", component: "x", promotionType: "securePipelines", checks: [] }],
+      $schema: "https://raw.githubusercontent.com/govuk-one-login/quality-gates/refs/tags/v0.14.0/schemas/schema.json",
+      services: [{ product: "x", component: "x", promotionType: "securePipelines", automated: [] }],
     });
     const before = readFileSync(file, "utf8");
 
@@ -88,8 +89,8 @@ describe("upgrade command", () => {
 
     const a = JSON.parse(readFileSync(join(TMP, "a", "quality-gate.manifest.json"), "utf8"));
     const b = JSON.parse(readFileSync(join(TMP, "b", "quality-gate.manifest.json"), "utf8"));
-    assert.match(a.$schema, /v0\.13\.0/);
-    assert.match(b.$schema, /v0\.13\.0/);
+    assert.match(a.$schema, /v0\.14\.0/);
+    assert.match(b.$schema, /v0\.14\.0/);
     assert.equal(b.services[0].product, "b");
     assert.equal(b.services[0].component, "b");
   });

--- a/cli/middleware/load-stack-orch.js
+++ b/cli/middleware/load-stack-orch.js
@@ -5,7 +5,7 @@ import { existsSync } from "node:fs";
 export function loadStackOrch(argv) {
   const files = new Set();
   for (const service of argv.manifest?.services ?? []) {
-    for (const check of service.checks ?? []) {
+    for (const check of [...(service.automated ?? []), ...(service.outOfBand ?? [])]) {
       if (check.provider === "Stack Orchestration Tool" && check.config?.file?.endsWith(".json")) {
         files.add(check.config.file);
       }

--- a/cli/middleware/load-stack-orch.test.js
+++ b/cli/middleware/load-stack-orch.test.js
@@ -14,7 +14,7 @@ describe("loadStackOrch", () => {
           product: "example-product",
           component: "frontend",
           promotionType: "securePipelines",
-          checks: [{
+          automated: [{
             checkTypes: ["secret scanning"],
             phase: "pre-merge",
             provider: "GitHub",
@@ -41,7 +41,7 @@ describe("loadStackOrch", () => {
           product: "example-product",
           component: "infra",
           promotionType: "securePipelines",
-          checks: [{
+          automated: [{
             checkTypes: ["product"],
             phase: "build",
             provider: "Stack Orchestration Tool",
@@ -62,7 +62,7 @@ describe("loadStackOrch", () => {
           product: "example-product",
           component: "infra",
           promotionType: "securePipelines",
-          checks: [{
+          automated: [{
             checkTypes: ["product"],
             phase: "build",
             provider: "Stack Orchestration Tool",
@@ -94,7 +94,7 @@ describe("loadStackOrch", () => {
           product: "example-product",
           component: "backend",
           promotionType: "securePipelines",
-          checks: [{
+          automated: [{
             checkTypes: ["product"],
             phase: "build",
             provider: "Stack Orchestration Tool",

--- a/cli/middleware/load-terraform.js
+++ b/cli/middleware/load-terraform.js
@@ -5,7 +5,7 @@ import { existsSync } from "node:fs";
 export function loadTerraform(argv) {
   const tfFiles = new Set();
   for (const service of argv.manifest?.services ?? []) {
-    for (const check of service.checks ?? []) {
+    for (const check of [...(service.automated ?? []), ...(service.outOfBand ?? [])]) {
       if (check.provider === "Terraform" && check.config?.file?.endsWith(".tf")) {
         tfFiles.add(check.config.file);
       }

--- a/cli/middleware/load-terraform.test.js
+++ b/cli/middleware/load-terraform.test.js
@@ -11,7 +11,7 @@ describe("loadTerraform", () => {
           product: "example-product",
           component: "frontend",
           promotionType: "securePipelines",
-          checks: [{
+          automated: [{
             checkTypes: ["secret scanning"],
             phase: "pre-merge",
             provider: "GitHub",
@@ -40,7 +40,7 @@ describe("loadTerraform", () => {
           product: "example-product",
           component: "infra",
           promotionType: "securePipelines",
-          checks: [{
+          automated: [{
             checkTypes: ["product"],
             phase: "build",
             provider: "Terraform",
@@ -62,7 +62,7 @@ describe("loadTerraform", () => {
           product: "example-product",
           component: "infra",
           promotionType: "securePipelines",
-          checks: [{
+          automated: [{
             checkTypes: ["product"],
             phase: "build",
             provider: "Terraform",

--- a/cli/upgrades/index.js
+++ b/cli/upgrades/index.js
@@ -5,6 +5,7 @@ import { transform as v0100 } from "./v0.10.0.js";
 import { transform as v0110 } from "./v0.11.0.js";
 import { transform as v0120 } from "./v0.12.0.js";
 import { transform as v0130 } from "./v0.13.0.js";
+import { transform as v0140 } from "./v0.14.0.js";
 
 const SCHEMA_URL_PREFIX = "https://raw.githubusercontent.com/govuk-one-login/quality-gates/refs/tags/v";
 
@@ -16,6 +17,7 @@ const transforms = [
   { version: [0, 11, 0], transform: v0110 },
   { version: [0, 12, 0], transform: v0120 },
   { version: [0, 13, 0], transform: v0130 },
+  { version: [0, 14, 0], transform: v0140 },
 ];
 
 export function parseVersion(schema) {

--- a/cli/upgrades/upgrades.test.js
+++ b/cli/upgrades/upgrades.test.js
@@ -8,6 +8,7 @@ import { transform as v0100 } from "./v0.10.0.js";
 import { transform as v0110 } from "./v0.11.0.js";
 import { transform as v0120 } from "./v0.12.0.js";
 import { transform as v0130 } from "./v0.13.0.js";
+import { transform as v0140 } from "./v0.14.0.js";
 
 describe("parseVersion", () => {
   it("extracts version from schema URL", () => {
@@ -23,32 +24,35 @@ describe("parseVersion", () => {
 
 describe("getTransforms", () => {
   it("returns all transforms for null version", () => {
-    assert.equal(getTransforms(null).length, 7);
+    assert.equal(getTransforms(null).length, 8);
   });
   it("returns all transforms for v0.1.0", () => {
-    assert.equal(getTransforms([0, 1, 0]).length, 7);
+    assert.equal(getTransforms([0, 1, 0]).length, 8);
   });
-  it("returns v0.7.0 through v0.13.0 for v0.5.0", () => {
+  it("returns v0.7.0 through v0.14.0 for v0.5.0", () => {
     const t = getTransforms([0, 5, 0]);
-    assert.equal(t.length, 6);
+    assert.equal(t.length, 7);
   });
-  it("returns v0.9.0 through v0.13.0 for v0.7.0", () => {
-    assert.equal(getTransforms([0, 7, 0]).length, 5);
+  it("returns v0.9.0 through v0.14.0 for v0.7.0", () => {
+    assert.equal(getTransforms([0, 7, 0]).length, 6);
   });
-  it("returns v0.10.0 through v0.13.0 for v0.9.0", () => {
-    assert.equal(getTransforms([0, 9, 0]).length, 4);
+  it("returns v0.10.0 through v0.14.0 for v0.9.0", () => {
+    assert.equal(getTransforms([0, 9, 0]).length, 5);
   });
-  it("returns v0.11.0 through v0.13.0 for v0.10.0", () => {
-    assert.equal(getTransforms([0, 10, 0]).length, 3);
+  it("returns v0.11.0 through v0.14.0 for v0.10.0", () => {
+    assert.equal(getTransforms([0, 10, 0]).length, 4);
   });
-  it("returns v0.12.0 and v0.13.0 for v0.11.0", () => {
-    assert.equal(getTransforms([0, 11, 0]).length, 2);
+  it("returns v0.12.0 through v0.14.0 for v0.11.0", () => {
+    assert.equal(getTransforms([0, 11, 0]).length, 3);
   });
-  it("returns only v0.13.0 for v0.12.0", () => {
-    assert.equal(getTransforms([0, 12, 0]).length, 1);
+  it("returns v0.13.0 and v0.14.0 for v0.12.0", () => {
+    assert.equal(getTransforms([0, 12, 0]).length, 2);
   });
-  it("returns nothing for v0.13.0", () => {
-    assert.equal(getTransforms([0, 13, 0]).length, 0);
+  it("returns only v0.14.0 for v0.13.0", () => {
+    assert.equal(getTransforms([0, 13, 0]).length, 1);
+  });
+  it("returns nothing for v0.14.0", () => {
+    assert.equal(getTransforms([0, 14, 0]).length, 0);
   });
 });
 
@@ -217,8 +221,40 @@ describe("v0.13.0 transform", () => {
   });
 });
 
+describe("v0.14.0 transform", () => {
+  it("renames checks to automated", () => {
+    const input = {
+      $schema: schemaUrl("0.13.0"),
+      services: [{ product: "svc", component: "api", promotionType: "securePipelines", checks: [{ checkTypes: ["unit"], phase: "pre-merge", provider: "GitHub", config: { file: "a.yml", path: "$.jobs.test" } }] }],
+    };
+    const result = v0140(input);
+    assert.equal(result.$schema, schemaUrl("0.14.0"));
+    assert.deepEqual(result.services[0].automated[0].checkTypes, ["unit"]);
+    assert.equal(result.services[0].checks, undefined);
+  });
+
+  it("handles empty checks array", () => {
+    const input = {
+      $schema: schemaUrl("0.13.0"),
+      services: [{ product: "svc", component: "api", promotionType: "securePipelines", checks: [] }],
+    };
+    const result = v0140(input);
+    assert.deepEqual(result.services[0].automated, []);
+    assert.equal(result.services[0].checks, undefined);
+  });
+
+  it("handles missing checks property", () => {
+    const input = {
+      $schema: schemaUrl("0.13.0"),
+      services: [{ product: "svc", component: "api", promotionType: "securePipelines" }],
+    };
+    const result = v0140(input);
+    assert.deepEqual(result.services[0].automated, []);
+  });
+});
+
 describe("full pipeline", () => {
-  it("upgrades v0.1.0 manifest to v0.13.0", () => {
+  it("upgrades v0.1.0 manifest to v0.14.0", () => {
     const input = {
       $schema: "https://raw.githubusercontent.com/govuk-one-login/quality-gates/refs/tags/v0.1.0/schemas/schema.json",
       services: [{
@@ -235,14 +271,15 @@ describe("full pipeline", () => {
       result = transform(result);
     }
 
-    assert.equal(result.$schema, schemaUrl("0.13.0"));
+    assert.equal(result.$schema, schemaUrl("0.14.0"));
     assert.equal(result.services[0].product, "example");
     assert.equal(result.services[0].component, "example");
     assert.equal(result.services[0].serviceTag, undefined);
     assert.equal(result.services[0].promotionType, "securePipelines");
-    assert.deepEqual(result.services[0].checks[0].checkTypes, ["integration"]);
-    assert.deepEqual(result.services[0].checks[0].provider, "Stack Orchestration Tool");
-    assert.equal(result.services[0].checks[0].config.path, "$.jobs.build");
-    assert.equal(result.services[0].checks[0].config.name, undefined);
+    assert.deepEqual(result.services[0].automated[0].checkTypes, ["integration"]);
+    assert.deepEqual(result.services[0].automated[0].provider, "Stack Orchestration Tool");
+    assert.equal(result.services[0].automated[0].config.path, "$.jobs.build");
+    assert.equal(result.services[0].automated[0].config.name, undefined);
+    assert.equal(result.services[0].checks, undefined);
   });
 });

--- a/cli/upgrades/v0.14.0.js
+++ b/cli/upgrades/v0.14.0.js
@@ -1,0 +1,11 @@
+import { schemaUrl } from "./index.js";
+
+export function transform(manifest) {
+  return {
+    $schema: schemaUrl("0.14.0"),
+    services: (manifest.services || []).map(({ checks, ...rest }) => ({
+      ...rest,
+      automated: checks || [],
+    })),
+  };
+}

--- a/cli/validators/mismatched-jobs.js
+++ b/cli/validators/mismatched-jobs.js
@@ -7,7 +7,7 @@ export function findMismatchedJobs(data) {
 
   return data.manifest.services.flatMap((s) => {
     const service = s.product || s.serviceTag || s["service-tag"];
-    const checks = s.checks || s.qualityGates || s["quality-gates"] || [];
+    const checks = [...(s.automated || []), ...(s.outOfBand || [])];
     return checks.flatMap((g) => {
       if (g.provider !== "GitHub") return [];
       if (!g.config.path) return [];

--- a/cli/validators/mismatched-jobs.test.js
+++ b/cli/validators/mismatched-jobs.test.js
@@ -2,9 +2,9 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { findMismatchedJobs } from "./mismatched-jobs.js";
 
-const makeData = (checks, jobs) => ({
+const makeData = (automated, jobs) => ({
   manifest: {
-    services: [{ product: "my-service", component: "api", checks }],
+    services: [{ product: "my-service", component: "api", automated }],
   },
   workflows: [{ name: "ci.yml", jobs }],
 });

--- a/cli/validators/mismatched-stack-orch.js
+++ b/cli/validators/mismatched-stack-orch.js
@@ -3,7 +3,7 @@ import { resolveStackOrchPath } from "../utils/stack-orch-path.js";
 export function findMismatchedStackOrch(data) {
   return data.manifest.services.flatMap((s) => {
     const service = s.product;
-    return (s.checks ?? []).flatMap((check) => {
+    return [...(s.automated ?? []), ...(s.outOfBand ?? [])].flatMap((check) => {
       if (check.provider !== "Stack Orchestration Tool") return [];
       if (!check.config?.file?.endsWith(".json")) return [];
 

--- a/cli/validators/mismatched-stack-orch.test.js
+++ b/cli/validators/mismatched-stack-orch.test.js
@@ -2,9 +2,9 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { findMismatchedStackOrch } from "./mismatched-stack-orch.js";
 
-const makeData = (checks, stackOrch) => ({
+const makeData = (automated, stackOrch) => ({
   manifest: {
-    services: [{ product: "example-product", component: "backend", checks }],
+    services: [{ product: "example-product", component: "backend", automated }],
   },
   stackOrch,
 });

--- a/cli/validators/mismatched-terraform.js
+++ b/cli/validators/mismatched-terraform.js
@@ -3,7 +3,7 @@ import { resolveTerraformPath } from "../utils/terraform-path.js";
 export function findMismatchedTerraform(data) {
   return data.manifest.services.flatMap((s) => {
     const service = s.product;
-    return (s.checks ?? []).flatMap((check) => {
+    return [...(s.automated ?? []), ...(s.outOfBand ?? [])].flatMap((check) => {
       if (check.provider !== "Terraform") return [];
       if (!check.config?.file?.endsWith(".tf")) return [];
 

--- a/cli/validators/mismatched-terraform.test.js
+++ b/cli/validators/mismatched-terraform.test.js
@@ -2,9 +2,9 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { findMismatchedTerraform } from "./mismatched-terraform.js";
 
-const makeData = (checks, terraform) => ({
+const makeData = (automated, terraform) => ({
   manifest: {
-    services: [{ product: "example-product", component: "infra", checks }],
+    services: [{ product: "example-product", component: "infra", automated }],
   },
   terraform,
 });

--- a/cli/validators/missing-workflows.js
+++ b/cli/validators/missing-workflows.js
@@ -4,7 +4,7 @@ export function findMissingWorkflows(data) {
 
   return data.manifest.services.flatMap((s) => {
     const service = s.product || s.serviceTag || s["service-tag"];
-    const checks = s.checks || s.qualityGates || s["quality-gates"] || [];
+    const checks = [...(s.automated || []), ...(s.outOfBand || [])];
     return checks
       .filter((g) => g.config.file.startsWith(".github/workflows/"))
       .filter((g) => !workflowNames.has(g.config.file.replace(".github/workflows/", "")))

--- a/cli/validators/missing-workflows.test.js
+++ b/cli/validators/missing-workflows.test.js
@@ -9,7 +9,7 @@ describe("findMissingWorkflows", () => {
         services: [{
           product: "my-service",
           component: "api",
-          checks: [{ config: { file: ".github/workflows/test.yml" } }],
+          automated: [{ config: { file: ".github/workflows/test.yml" } }],
         }],
       },
       workflows: [{ name: "test.yml", jobs: {} }],
@@ -23,7 +23,7 @@ describe("findMissingWorkflows", () => {
         services: [{
           product: "my-service",
           component: "api",
-          checks: [{ config: { file: ".github/workflows/missing.yml" } }],
+          automated: [{ config: { file: ".github/workflows/missing.yml" } }],
         }],
       },
       workflows: [{ name: "other.yml", jobs: {} }],
@@ -42,7 +42,7 @@ describe("findMissingWorkflows", () => {
         services: [{
           product: "svc",
           component: "api",
-          checks: [
+          automated: [
             { config: { file: ".github/workflows/a.yml" } },
             { config: { file: ".github/workflows/b.yml" } },
           ],
@@ -59,7 +59,7 @@ describe("findMissingWorkflows", () => {
         services: [{
           product: "svc",
           component: "api",
-          checks: [
+          automated: [
             { config: { file: "terraform/main.tf" } },
             { config: { file: "ci/stack-orchestration/parameters.json" } },
           ],

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,12 +22,21 @@ This repository provides a schema-driven approach to documenting quality gates a
 
 ### Quality gates
 
-A quality gate is an enforced check that must pass before code progresses to the next phase. Each gate has:
+A quality gate is an enforced check that must pass before code progresses to the next phase. Gates are grouped by **execution mode**:
+
+- **Automated** — checks that run in CI/CD automatically (e.g. unit tests, linting, security scanning)
+- **Manual** — checks performed by a human (e.g. accessibility audits, pen tests)
+- **Out-of-band** — checks that run outside the deployment pipeline (e.g. daily smoke tests, periodic scans)
+- **Not applicable** — check types consciously declared as irrelevant for a service
+
+Each automated and out-of-band gate has:
 
 - A **type** describing what it checks (unit tests, linting, security scanning, etc.)
 - A **phase** indicating when in the SDLC it runs
 - A **provider** identifying the platform that executes it
 - A **config** pointing to where the check is defined
+
+Manual gates have a type, phase, and free-text details describing the process. Not-applicable declarations list the check types with justification.
 
 #### Deployment strategy
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,7 +10,7 @@ Add a `$schema` property pointing to a tagged release:
 
 ```json
 {
-  "$schema": "https://raw.githubusercontent.com/govuk-one-login/quality-gates/refs/tags/v0.0.0/schemas/schema.json"
+  "$schema": "https://raw.githubusercontent.com/govuk-one-login/quality-gates/refs/tags/v0.14.0/schemas/schema.json"
 }
 ```
 
@@ -70,6 +70,31 @@ node cli/index.js cache clear
 > **Note:** Schema URLs pointing to branches (e.g. `refs/heads/...`) may become stale.
 > Use `--force` on the validate command to re-download, or `cache clear` to wipe all cached schemas.
 
+#### `upgrade`
+
+Incrementally upgrades manifest files to the latest schema version. Each version migration is applied in sequence.
+
+```shell
+# Upgrade manifest in the current directory
+node cli/index.js upgrade
+
+# Upgrade a specific file
+node cli/index.js upgrade path/to/quality-gate.manifest.json
+
+# Upgrade all manifests in a directory tree
+node cli/index.js upgrade path/to/repos/
+
+# Preview changes without writing
+node cli/index.js upgrade . --dry-run
+```
+
+The upgrade command handles all historical schema migrations automatically, including:
+
+- Kebab-case to camelCase property renames (pre-v0.5.0)
+- `qualityGates` → `checks` rename (v0.10.0)
+- `serviceTag` → `product`/`component` (v0.13.0)
+- `checks` → `automated` execution mode split (v0.14.0)
+
 ### Exit codes
 
 | Code | Meaning                     |
@@ -99,22 +124,61 @@ A manifest contains an array of **services**, each with:
 | `product`       | string | General name for a service                                            |
 | `component`     | string | Component within the product                                          |
 | `promotionType` | string | Promotion strategy (`securePipelines`, `gitFlow`, `library`, `other`) |
-| `checks`        | array  | List of quality gate checks                                           |
+| `automated`     | array  | Checks that run in CI/CD automatically (optional)                     |
+| `manual`        | array  | Checks performed by a human (optional)                                |
+| `outOfBand`     | array  | Checks that run outside the deployment pipeline (optional)            |
+| `notApplicable` | object | Check types consciously declared as not relevant (optional)           |
 
-Each **quality gate** contains:
+### Execution modes
 
-| Field         | Type     | Description                                                 |
-|---------------|----------|-------------------------------------------------------------|
-| `check-types` | string[] | Categories of check (see [check types](#check-types))       |
-| `phase`       | string   | SDLC phase where the check runs                             |
-| `provider`    | string   | Platform running the check (`GitHub`, `Stack Orchestrator`) |
-| `config`      | object   | Location of the check definition                            |
+Quality gate checks are grouped by how they are executed. This separates the *category* of check (e.g. "accessibility") from the *mechanism* by which it is verified.
+
+#### `automated`
+
+Checks that run automatically in CI/CD with no human involvement.
+
+| Field       | Type     | Required | Description                                      |
+|-------------|----------|----------|--------------------------------------------------|
+| `checkTypes`| string[] | Yes      | Categories of check (see [check types](#check-types)) |
+| `phase`     | string   | Yes      | SDLC phase where the check runs                  |
+| `provider`  | string   | Yes      | Platform running the check (`GitHub`, `Terraform`, `CloudFormation`, `Stack Orchestration Tool`) |
+| `config`    | object   | Yes      | Location of the check definition                 |
+
+#### `manual`
+
+Checks performed by a human (e.g. accessibility audit, pen test, manual approval gate).
+
+| Field       | Type     | Required | Description                                      |
+|-------------|----------|----------|--------------------------------------------------|
+| `checkTypes`| string[] | Yes      | Categories of check                              |
+| `phase`     | string   | Yes      | SDLC phase where the check is performed          |
+| `details`   | string[] | Yes      | Description of the manual process                |
+
+#### `outOfBand`
+
+Checks that happen outside the deployment pipeline (e.g. daily smoke tests, periodic security scans, external audits).
+
+| Field       | Type     | Required | Description                                      |
+|-------------|----------|----------|--------------------------------------------------|
+| `checkTypes`| string[] | Yes      | Categories of check                              |
+| `phase`     | string   | Yes      | SDLC phase the check relates to                  |
+| `provider`  | string   | Yes      | Platform running the check                       |
+| `config`    | object   | Yes      | Location of the check definition                 |
+
+#### `notApplicable`
+
+Check types that the team has consciously decided do not apply to this service.
+
+| Field       | Type     | Required | Description                                      |
+|-------------|----------|----------|--------------------------------------------------|
+| `checkTypes`| string[] | Yes      | Check types that are not applicable              |
+| `details`   | string[] | Yes      | Justification for why they are not applicable    |
 
 ### Check types
 
 The schema supports the following check-type values:
 
-`accessibility`, `canary`, `code quality`, `code style and linting`, `component`, `contract`, `cross service integration`, `data compatibility`, `e2e`, `integration`, `manual`, `neighbour`, `new feature`, `product`, `regression`, `secret scanning`, `sensitive data scanning`, `smoke`, `stack`, `system`, `unit test coverage`, `unit`, `visual regression`, `vulnerability detection`
+`accessibility`, `canary`, `code quality`, `code style and linting`, `component`, `contract`, `cross service integration`, `data compatibility`, `e2e`, `integration`, `neighbour`, `new feature`, `product`, `regression`, `secret scanning`, `sensitive data scanning`, `smoke`, `stack`, `system`, `unit test coverage`, `unit`, `visual regression`, `vulnerability detection`
 
 ### Phases
 

--- a/examples/github-gitflow.json
+++ b/examples/github-gitflow.json
@@ -4,7 +4,7 @@
       "product": "service-name",
       "component": "frontend",
       "promotionType": "gitFlow",
-      "checks": [
+      "automated": [
         {
           "checkTypes": ["code style and linting"],
           "provider": "GitHub",

--- a/examples/github-librarysdk.json
+++ b/examples/github-librarysdk.json
@@ -4,7 +4,7 @@
       "product": "service-name",
       "component": "frontend",
       "promotionType": "library",
-      "checks": [
+      "automated": [
         {
           "checkTypes": ["unit"],
           "provider": "GitHub",

--- a/examples/github-other.json
+++ b/examples/github-other.json
@@ -5,7 +5,7 @@
       "component": "frontend",
       "promotionType": "other",
       "promotionTypeDetails": ["custom deployment tool"],
-      "checks": [
+      "automated": [
         {
           "checkTypes": ["unit"],
           "provider": "GitHub",

--- a/examples/github-trunk.json
+++ b/examples/github-trunk.json
@@ -4,7 +4,7 @@
       "product": "service-name",
       "component": "frontend",
       "promotionType": "securePipelines",
-      "checks": [
+      "automated": [
         {
           "checkTypes": ["unit"],
           "provider": "GitHub",

--- a/examples/github.json
+++ b/examples/github.json
@@ -4,7 +4,7 @@
       "product": "service-name",
       "component": "frontend",
       "promotionType": "securePipelines",
-      "checks": [
+      "automated": [
         {
           "checkTypes": ["code style and linting"],
           "provider": "GitHub",

--- a/quality-gate.manifest.json
+++ b/quality-gate.manifest.json
@@ -5,7 +5,7 @@
       "product": "quality-gates",
       "component": "quality-gates",
       "promotionType": "library",
-      "checks": [
+      "automated": [
         {
           "checkTypes": ["unit"],
           "phase": "pre-merge",

--- a/schemas/schema.json
+++ b/schemas/schema.json
@@ -9,7 +9,7 @@
           "product": "service-name",
           "component": "frontend",
           "promotionType": "securePipelines",
-          "checks": [
+          "automated": [
             {
               "checkTypes": ["code style and linting"],
               "provider": "GitHub",
@@ -31,7 +31,7 @@
     }
   },
   "$defs": {
-    "check": {
+    "automated-check": {
       "type": "object",
       "properties": {
         "checkTypes": {
@@ -57,6 +57,72 @@
         "phase",
         "provider",
         "config"
+      ]
+    },
+    "manual-check": {
+      "type": "object",
+      "properties": {
+        "checkTypes": {
+          "$ref": "#/$defs/check-types"
+        },
+        "phase": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1
+        }
+      },
+      "required": [
+        "checkTypes",
+        "phase",
+        "details"
+      ]
+    },
+    "out-of-band-check": {
+      "type": "object",
+      "properties": {
+        "checkTypes": {
+          "$ref": "#/$defs/check-types"
+        },
+        "phase": {
+          "type": "string"
+        },
+        "provider": {
+          "enum": [
+            "CloudFormation",
+            "GitHub",
+            "Stack Orchestration Tool",
+            "Terraform"
+          ]
+        },
+        "config": {
+          "$ref": "#/$defs/check-config"
+        }
+      },
+      "required": [
+        "checkTypes",
+        "phase",
+        "provider",
+        "config"
+      ]
+    },
+    "not-applicable": {
+      "type": "object",
+      "properties": {
+        "checkTypes": {
+          "$ref": "#/$defs/check-types"
+        },
+        "details": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1
+        }
+      },
+      "required": [
+        "checkTypes",
+        "details"
       ]
     },
     "check-config": {
@@ -101,7 +167,6 @@
         "unit",
         "visual regression",
         "vulnerability detection",
-        "manual",
         "integration"
       ]
     },
@@ -111,16 +176,46 @@
         "$ref": "#/$defs/check-type"
       }
     },
-    "checks": {
+    "automated-checks": {
       "type": "array",
       "items": {
-        "$ref": "#/$defs/check"
+        "$ref": "#/$defs/automated-check"
+      }
+    },
+    "manual-checks": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/manual-check"
+      }
+    },
+    "out-of-band-checks": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/out-of-band-check"
       }
     },
     "secure-pipelines-phases": {
       "type": "object",
       "properties": {
-        "checks": {
+        "automated": {
+          "items": {
+            "properties": {
+              "phase": {
+                "enum": ["pre-merge", "pre-upload", "build", "staging", "production", "integration"]
+              }
+            }
+          }
+        },
+        "manual": {
+          "items": {
+            "properties": {
+              "phase": {
+                "enum": ["pre-merge", "pre-upload", "build", "staging", "production", "integration"]
+              }
+            }
+          }
+        },
+        "outOfBand": {
           "items": {
             "properties": {
               "phase": {
@@ -134,7 +229,25 @@
     "git-flow-phases": {
       "type": "object",
       "properties": {
-        "checks": {
+        "automated": {
+          "items": {
+            "properties": {
+              "phase": {
+                "enum": ["pre-develop", "develop", "pre-release", "release", "main"]
+              }
+            }
+          }
+        },
+        "manual": {
+          "items": {
+            "properties": {
+              "phase": {
+                "enum": ["pre-develop", "develop", "pre-release", "release", "main"]
+              }
+            }
+          }
+        },
+        "outOfBand": {
           "items": {
             "properties": {
               "phase": {
@@ -148,7 +261,25 @@
     "library-phases": {
       "type": "object",
       "properties": {
-        "checks": {
+        "automated": {
+          "items": {
+            "properties": {
+              "phase": {
+                "enum": ["pre-merge", "pre-release"]
+              }
+            }
+          }
+        },
+        "manual": {
+          "items": {
+            "properties": {
+              "phase": {
+                "enum": ["pre-merge", "pre-release"]
+              }
+            }
+          }
+        },
+        "outOfBand": {
           "items": {
             "properties": {
               "phase": {
@@ -162,15 +293,11 @@
     "service": {
       "type": "object",
       "required": [
-        "checks",
         "product",
         "component",
         "promotionType"
       ],
       "properties": {
-        "checks": {
-          "$ref": "#/$defs/checks"
-        },
         "product": {
           "type": "string"
         },
@@ -189,6 +316,18 @@
           "type": "array",
           "items": { "type": "string" },
           "minItems": 1
+        },
+        "automated": {
+          "$ref": "#/$defs/automated-checks"
+        },
+        "manual": {
+          "$ref": "#/$defs/manual-checks"
+        },
+        "outOfBand": {
+          "$ref": "#/$defs/out-of-band-checks"
+        },
+        "notApplicable": {
+          "$ref": "#/$defs/not-applicable"
         }
       },
       "allOf": [

--- a/test/check-types.json
+++ b/test/check-types.json
@@ -11,7 +11,7 @@
             "product": "generic-service",
             "component": "api",
             "promotionType": "securePipelines",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["integration"],
                 "provider": "GitHub",
@@ -35,7 +35,7 @@
             "product": "generic-service",
             "component": "api",
             "promotionType": "securePipelines",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["component"],
                 "provider": "GitHub",
@@ -59,7 +59,7 @@
             "product": "generic-service",
             "component": "api",
             "promotionType": "securePipelines",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["product"],
                 "provider": "GitHub",
@@ -83,7 +83,7 @@
             "product": "generic-service",
             "component": "api",
             "promotionType": "securePipelines",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["neighbour"],
                 "provider": "GitHub",
@@ -107,7 +107,7 @@
             "product": "generic-service",
             "component": "api",
             "promotionType": "securePipelines",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["e2e"],
                 "provider": "GitHub",

--- a/test/gitflow.json
+++ b/test/gitflow.json
@@ -11,7 +11,7 @@
             "product": "generic-service",
             "component": "api",
             "promotionType": "gitFlow",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["unit"],
                 "provider": "GitHub",

--- a/test/jsonpath.json
+++ b/test/jsonpath.json
@@ -11,7 +11,7 @@
             "product": "service",
             "component": "api",
             "promotionType": "securePipelines",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["unit"],
                 "provider": "GitHub",
@@ -35,7 +35,7 @@
             "product": "service",
             "component": "api",
             "promotionType": "securePipelines",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["unit"],
                 "provider": "GitHub",
@@ -59,7 +59,7 @@
             "product": "service",
             "component": "api",
             "promotionType": "securePipelines",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["unit"],
                 "provider": "GitHub",
@@ -83,7 +83,7 @@
             "product": "service",
             "component": "api",
             "promotionType": "securePipelines",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["integration"],
                 "provider": "Stack Orchestration Tool",
@@ -107,7 +107,7 @@
             "product": "service",
             "component": "api",
             "promotionType": "securePipelines",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["unit"],
                 "provider": "GitHub",
@@ -131,7 +131,7 @@
             "product": "service",
             "component": "api",
             "promotionType": "securePipelines",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["unit"],
                 "provider": "Terraform",
@@ -154,7 +154,7 @@
             "product": "service",
             "component": "api",
             "promotionType": "securePipelines",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["integration"],
                 "provider": "Terraform",
@@ -177,7 +177,7 @@
             "product": "service",
             "component": "api",
             "promotionType": "securePipelines",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["unit"],
                 "provider": "GitHub",

--- a/test/librarysdk.json
+++ b/test/librarysdk.json
@@ -11,7 +11,7 @@
             "product": "generic-service",
             "component": "api",
             "promotionType": "library",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["unit"],
                 "provider": "GitHub",

--- a/test/other.json
+++ b/test/other.json
@@ -12,7 +12,7 @@
             "component": "api",
             "promotionType": "other",
             "promotionTypeDetails": ["custom pipeline"],
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["unit"],
                 "provider": "GitHub",
@@ -37,7 +37,7 @@
             "component": "api",
             "promotionType": "other",
             "promotionTypeDetails": ["custom pipeline", "manual approval"],
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["unit"],
                 "provider": "GitHub",
@@ -62,7 +62,7 @@
             "component": "api",
             "promotionType": "other",
             "promotionTypeDetails": ["custom deployment tool"],
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["unit"],
                 "provider": "GitHub",
@@ -86,7 +86,7 @@
             "product": "service",
             "component": "api",
             "promotionType": "other",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["unit"],
                 "provider": "GitHub",
@@ -111,7 +111,7 @@
             "component": "api",
             "promotionType": "other",
             "promotionTypeDetails": [],
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["unit"],
                 "provider": "GitHub",
@@ -136,7 +136,7 @@
             "component": "api",
             "promotionType": "other",
             "promotionTypeDetails": [123],
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["unit"],
                 "provider": "GitHub",

--- a/test/promotion-type.json
+++ b/test/promotion-type.json
@@ -11,7 +11,7 @@
             "product": "service",
             "component": "api",
             "promotionType": "securePipelines",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["unit"],
                 "provider": "GitHub",
@@ -35,7 +35,7 @@
             "product": "service",
             "component": "api",
             "promotionType": "securePipelines",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["unit"],
                 "provider": "GitHub",
@@ -59,7 +59,7 @@
             "product": "service",
             "component": "api",
             "promotionType": "gitFlow",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["unit"],
                 "provider": "GitHub",
@@ -83,7 +83,7 @@
             "product": "service",
             "component": "api",
             "promotionType": "gitFlow",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["unit"],
                 "provider": "GitHub",
@@ -107,7 +107,7 @@
             "product": "service",
             "component": "api",
             "promotionType": "library",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["unit"],
                 "provider": "GitHub",
@@ -131,7 +131,7 @@
             "product": "service",
             "component": "api",
             "promotionType": "library",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["unit"],
                 "provider": "GitHub",
@@ -154,7 +154,7 @@
           {
             "product": "service",
             "component": "api",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["unit"],
                 "provider": "GitHub",
@@ -178,7 +178,7 @@
             "product": "service",
             "component": "api",
             "promotionType": "unknown",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["unit"],
                 "provider": "GitHub",
@@ -202,7 +202,7 @@
             "product": "service",
             "component": "api",
             "promotionType": "other",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["unit"],
                 "provider": "GitHub",

--- a/test/provider.json
+++ b/test/provider.json
@@ -11,7 +11,7 @@
             "product": "service",
             "component": "api",
             "promotionType": "securePipelines",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["unit"],
                 "provider": "GitHub",
@@ -35,7 +35,7 @@
             "product": "service",
             "component": "api",
             "promotionType": "securePipelines",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["unit"],
                 "provider": "Terraform",
@@ -58,7 +58,7 @@
             "product": "service",
             "component": "api",
             "promotionType": "securePipelines",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["unit"],
                 "provider": "CloudFormation",
@@ -81,7 +81,7 @@
             "product": "service",
             "component": "api",
             "promotionType": "securePipelines",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["unit"],
                 "provider": "Stack Orchestration Tool",
@@ -104,7 +104,7 @@
             "product": "service",
             "component": "api",
             "promotionType": "securePipelines",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["unit"],
                 "provider": "Jenkins",

--- a/test/trunk.json
+++ b/test/trunk.json
@@ -33,7 +33,7 @@
             "product": "generic-service",
             "component": "api",
             "promotionType": "securePipelines",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["unit"],
                 "provider": "GitHub",
@@ -57,7 +57,7 @@
             "product": "generic-service-1",
             "component": "api",
             "promotionType": "securePipelines",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["code style and linting"],
                 "provider": "GitHub",
@@ -73,7 +73,7 @@
             "product": "generic-service-2",
             "component": "api",
             "promotionType": "securePipelines",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["code style and linting"],
                 "provider": "GitHub",
@@ -97,7 +97,7 @@
             "product": "generic-service",
             "component": "api",
             "promotionType": "securePipelines",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["code style and linting"],
                 "provider": "GitHub",
@@ -113,7 +113,7 @@
             "product": "generic-service",
             "component": "api",
             "promotionType": "securePipelines",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["code style and linting"],
                 "provider": "GitHub",
@@ -137,7 +137,7 @@
             "product": "generic-service",
             "component": "api",
             "promotionType": "securePipelines",
-            "checks": [
+            "automated": [
               {
                 "checkTypes": ["unknown"],
                 "provider": "GitHub",

--- a/visualiser/src/components/manifest-and-workflows.js
+++ b/visualiser/src/components/manifest-and-workflows.js
@@ -35,7 +35,7 @@ export function flattenJobs (nodes) {
 export function flattenQualityGatesJobs(nodes) {
     return nodes.flatMap((node) =>
         (node.manifest?.text?.services ?? []).flatMap((service) =>
-            (service.checks ?? []).flatMap((gate) => {
+            [...(service.automated ?? []), ...(service.outOfBand ?? [])].flatMap((gate) => {
                 if (!gate.config?.file || !gate.config?.path) return [];
                 const parsed = parseCheckPath(gate.config.path);
                 if (!parsed.valid) return [];

--- a/visualiser/src/components/manifest-and-workflows.test.js
+++ b/visualiser/src/components/manifest-and-workflows.test.js
@@ -44,7 +44,7 @@ describe("manifest-and-workflows", () => {
                             services: [
                                 {
                                     "product": "service-a",
-                                    "checks": [
+                                    "automated": [
                                         {
                                             "checkTypes": ["code style and linting", "vulnerability detection"],
                                             "config": {
@@ -63,7 +63,7 @@ describe("manifest-and-workflows", () => {
                                 },
                                 {
                                     "product": "service-b",
-                                    "checks": [
+                                    "automated": [
                                         {
                                             "checkTypes": ["code style and linting", "vulnerability detection"],
                                             "config": {
@@ -189,7 +189,7 @@ describe("manifest-and-workflows", () => {
                     text: {
                         services: [{
                             "product": "service-a",
-                            "checks": [{
+                            "automated": [{
                                 "checkTypes": ["unit"],
                                 "config": {file: ".github/workflows/ci.yaml", path: "$.jobs['my-job']"}
                             }]
@@ -216,7 +216,7 @@ describe("manifest-and-workflows", () => {
                     text: {
                         services: [{
                             "product": "service-a",
-                            "checks": [{
+                            "automated": [{
                                 "checkTypes": ["unit"],
                                 "config": {file: ".github/workflows/ci.yaml", path: "$.jobs.build.steps[?@.name=='Run tests']"}
                             }]
@@ -243,7 +243,7 @@ describe("manifest-and-workflows", () => {
                     text: {
                         services: [{
                             "product": "service-a",
-                            "checks": [{
+                            "automated": [{
                                 "checkTypes": ["unit"],
                                 "config": {file: ".github/workflows/ci.yaml", path: "$.invalid[syntax"}
                             }]
@@ -267,7 +267,7 @@ describe("manifest-and-workflows", () => {
                     text: {
                         services: [{
                             "product": "service-a",
-                            "checks": [{
+                            "automated": [{
                                 "checkTypes": ["unit"],
                                 "config": {file: ".github/workflows/ci.yaml", path: "$.jobs.missing"}
                             }]
@@ -291,7 +291,7 @@ describe("manifest-and-workflows", () => {
                     text: {
                         services: [{
                             "product": "service-a",
-                            "checks": [{
+                            "automated": [{
                                 "checkTypes": ["unit"],
                                 "config": {file: ".github/workflows/ci.yaml", path: "jobs.build"}
                             }]
@@ -313,7 +313,7 @@ describe("manifest-and-workflows", () => {
         it("returns empty array for service with empty checks", () => {
             const nodes = [{
                 name: "repo-a",
-                manifest: {text: {services: [{"product": "service-a", "checks": []}]}},
+                manifest: {text: {services: [{"product": "service-a", "automated": []}]}},
                 workflows: {entries: []}
             }];
             assert.deepEqual(flattenQualityGatesJobs(nodes), []);
@@ -325,7 +325,7 @@ describe("manifest-and-workflows", () => {
                 manifest: {
                     text: {
                         services: [{
-                            "product": "service-a", "checks": [{
+                            "product": "service-a", "automated": [{
                                 "checkTypes": ["unit"],
                                 "config": {file: ".github/workflows/missing.yaml", path: "$.jobs.test"}
                             }]
@@ -344,7 +344,7 @@ describe("manifest-and-workflows", () => {
                     text: {
                         services: [{
                             "product": "service-a",
-                            "checks": [{"checkTypes": ["unit"]}]
+                            "automated": [{"checkTypes": ["unit"]}]
                         }]
                     }
                 },

--- a/visualiser/src/data/level-groups.json.js
+++ b/visualiser/src/data/level-groups.json.js
@@ -11,9 +11,9 @@ const schema = JSON.parse(readFileSync(schemaUrl, "utf8"))
 const checkTypes = schema.$defs["check-type"].enum
 const phases = [
     ...new Set([
-        ...schema.$defs["secure-pipelines-phases"].properties.checks.items.properties.phase.enum,
-        ...schema.$defs["git-flow-phases"].properties.checks.items.properties.phase.enum,
-        ...schema.$defs["library-phases"].properties.checks.items.properties.phase.enum,
+        ...schema.$defs["secure-pipelines-phases"].properties.automated.items.properties.phase.enum,
+        ...schema.$defs["git-flow-phases"].properties.automated.items.properties.phase.enum,
+        ...schema.$defs["library-phases"].properties.automated.items.properties.phase.enum,
     ])
 ]
 

--- a/visualiser/src/implementation-levels.md
+++ b/visualiser/src/implementation-levels.md
@@ -66,16 +66,12 @@ const phasesByPromotionType = {
 ```
 
 ```js
-// display(phasesByPromotionType)
-```
-
-```js
 // Flatten manifests into per-product/component/promotionType check implementations
 const productChecks = repositories
   .filter(node => node.manifest?.text?.services)
   .flatMap(node =>
     node.manifest.text.services.flatMap(service =>
-      (service.checks ?? []).flatMap(check =>
+      [...(service.automated ?? []), ...(service.manual ?? []), ...(service.outOfBand ?? [])].flatMap(check =>
         (check.checkTypes ?? []).map(ct => ({
           product: service.product,
           component: service.component,

--- a/visualiser/src/statistics-checks.md
+++ b/visualiser/src/statistics-checks.md
@@ -82,7 +82,7 @@ const stats = nodesWithManifest.flatMap((node) => {
   );
 
   return (node.manifest.text.services ?? []).flatMap((service) =>
-    (service.checks ?? []).flatMap((gate) => {
+    [...(service.automated ?? []), ...(service.outOfBand ?? [])].flatMap((gate) => {
       const workflowKey = gate.config.file
         .replace(".github/workflows/", "")
         .replace(/\.ya?ml$/, "");

--- a/visualiser/src/validation.md
+++ b/visualiser/src/validation.md
@@ -49,7 +49,7 @@ function findMissingWorkflows(node) {
     const workflowNames = new Set(node.workflows.entries.map((e) => e.name));
     const { manifest, workflows, ...rest } = node;
     return (node.manifest.text.services ?? []).flatMap((s) =>
-        (s.checks ?? [])
+        [...(s.automated ?? []), ...(s.outOfBand ?? [])]
             .filter((g) => !workflowNames.has(g.config.file.replace(".github/workflows/", "")))
             .map((g) => ({ ...rest, ...g, file: g.config.file.replace(".github/workflows/", "") }))
     );
@@ -111,7 +111,7 @@ function findGatesWithmismatchedCheckTypes(node) {
     const known = new Set(allCheckTypes);
     const { manifest, workflows, ...rest } = node;
     return (node.manifest.text.services ?? []).flatMap((s) =>
-        (s.checks ?? [])
+        [...(s.automated ?? []), ...(s.outOfBand ?? [])]
             .filter((g) => (g.checkTypes ?? []).some((t) => !known.has(t)))
             .map((g) => ({ ...rest, ...g, mismatchedCheckTypes: (g.checkTypes ?? []).filter((t) => !known.has(t)).join(", ") }))
     );
@@ -157,7 +157,7 @@ const checkTypeRepoView = view(Inputs.table(gatesWithmismatchedCheckTypes, {
 function getQualityGatesForRepo(name) {
     const node = nodesWithManifest.find((n) => n.name === name);
     return (node?.manifest.text.services ?? []).flatMap((s) =>
-        (s.checks ?? []).map((g) => ({ "product": s.product, ...g, "config.file": g.config.file, "config.name": g.config.name, "config.path": g.config.path, name: node.name, "pod.value": node.pod?.value, "teamResponsible.value": node.teamResponsible?.value }))
+        [...(s.automated ?? []), ...(s.outOfBand ?? [])].map((g) => ({ "product": s.product, ...g, "config.file": g.config.file, "config.name": g.config.name, "config.path": g.config.path, name: node.name, "pod.value": node.pod?.value, "teamResponsible.value": node.teamResponsible?.value }))
     );
 }
 ```
@@ -179,7 +179,7 @@ function findGatesWithmismatchedJobs(node) {
     );
     const { manifest, workflows, ...rest } = node;
     return (node.manifest.text.services ?? []).flatMap((s) =>
-        (s.checks ?? [])
+        [...(s.automated ?? []), ...(s.outOfBand ?? [])]
             .filter((g) => g.provider === "GitHub" && g.config.path)
             .flatMap((g) => {
                 const parsed = parseCheckPath(g.config.path);
@@ -262,7 +262,7 @@ Inputs.table(
 function findGatesWithInvalidPaths(node) {
     const { manifest, workflows, ...rest } = node;
     return (node.manifest.text.services ?? []).flatMap((s) =>
-        (s.checks ?? [])
+        [...(s.automated ?? []), ...(s.outOfBand ?? [])]
             .filter((g) => g.provider === "GitHub" && g.config.path && !parseCheckPath(g.config.path).valid)
             .map((g) => ({ ...rest, ...g, invalidPath: g.config.path }))
     );


### PR DESCRIPTION
Rework schema to use executionMode. This allows the description of:
- automated checks - this is the existing behaviour
- manual checks - this is currently implemented as a singular checkType
- outOfBand - a new category to cover automated tests not on the path to production. These are typically scheduled tests or performance tests
- notApplicable - amongst other things this allows backend systems to declare that accessibility tests are not applicable

This PR also includes upgrade scripts 