### PR TITLE
feat: Add scope and purpose

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Reference the schema directly in your manifest file:
 
 ```json
 {
-  "$schema": "https://raw.githubusercontent.com/govuk-one-login/quality-gates/refs/tags/v0.15.0/schemas/schema.json",
+  "$schema": "https://raw.githubusercontent.com/govuk-one-login/quality-gates/refs/tags/v0.16.0/schemas/schema.json",
   "services": [
     {
       "product": "my-service",
@@ -21,7 +21,7 @@ Reference the schema directly in your manifest file:
       "promotionType": "securePipelines",
       "automated": [
         {
-          "checks": [{ "name": "unit" }],
+          "checks": [{ "name": "unit", "purpose": ["regression"] }],
           "phase": "pre-merge",
           "provider": "GitHub",
           "config": {
@@ -39,7 +39,7 @@ Reference the schema directly in your manifest file:
       ],
       "outOfBand": [
         {
-          "checks": [{ "name": "smoke" }],
+          "checks": [{ "name": "integration", "scope": "e2e", "purpose": ["smoke"] }],
           "phase": "production",
           "provider": "GitHub",
           "config": {
@@ -104,7 +104,7 @@ See [visualiser/README.md](./visualiser/README.md).
 This schema follows [semantic versioning](https://semver.org/). The schema URL includes a version tag:
 
 ```
-https://raw.githubusercontent.com/govuk-one-login/quality-gates/refs/tags/v0.15.0/schemas/schema.json
+https://raw.githubusercontent.com/govuk-one-login/quality-gates/refs/tags/v0.16.0/schemas/schema.json
 ```
 
 - **Major** — breaking changes to the schema (removed fields, renamed enums)

--- a/cli/commands/upgrade.test.js
+++ b/cli/commands/upgrade.test.js
@@ -35,7 +35,7 @@ describe("upgrade command", () => {
     assert.equal(result.services[0].serviceTag, undefined);
     assert.equal(result.services[0].promotionType, "securePipelines");
     assert.deepEqual(result.services[0].automated[0].checks, [{ name: "unit" }]);
-    assert.match(result.$schema, /v0\.15\.0/);
+    assert.match(result.$schema, /v0\.16\.0/);
     assert.equal(result.services[0].automated[0].checkTypes, undefined);
   });
 
@@ -65,7 +65,7 @@ describe("upgrade command", () => {
 
   it("skips manifests already at latest version", () => {
     const file = createManifest(TMP, {
-      $schema: "https://raw.githubusercontent.com/govuk-one-login/quality-gates/refs/tags/v0.15.0/schemas/schema.json",
+      $schema: "https://raw.githubusercontent.com/govuk-one-login/quality-gates/refs/tags/v0.16.0/schemas/schema.json",
       services: [{ product: "x", component: "x", promotionType: "securePipelines", automated: [{ checks: [{ name: "unit" }], phase: "pre-merge", provider: "GitHub", config: { file: "a.yml", path: "$.jobs.test" } }] }],
     });
     const before = readFileSync(file, "utf8");
@@ -89,8 +89,8 @@ describe("upgrade command", () => {
 
     const a = JSON.parse(readFileSync(join(TMP, "a", "quality-gate.manifest.json"), "utf8"));
     const b = JSON.parse(readFileSync(join(TMP, "b", "quality-gate.manifest.json"), "utf8"));
-    assert.match(a.$schema, /v0\.15\.0/);
-    assert.match(b.$schema, /v0\.15\.0/);
+    assert.match(a.$schema, /v0\.16\.0/);
+    assert.match(b.$schema, /v0\.16\.0/);
     assert.equal(b.services[0].product, "b");
     assert.equal(b.services[0].component, "b");
   });

--- a/cli/middleware/load-stack-orch.test.js
+++ b/cli/middleware/load-stack-orch.test.js
@@ -42,7 +42,7 @@ describe("loadStackOrch", () => {
           component: "infra",
           promotionType: "securePipelines",
           automated: [{
-            checks: [{ name: "product" }],
+            checks: [{ name: "integration" }],
             phase: "build",
             provider: "Stack Orchestration Tool",
             config: { file: "config/params.yaml", path: "$[?@.ParameterKey=='X']" },
@@ -63,7 +63,7 @@ describe("loadStackOrch", () => {
           component: "infra",
           promotionType: "securePipelines",
           automated: [{
-            checks: [{ name: "product" }],
+            checks: [{ name: "integration" }],
             phase: "build",
             provider: "Stack Orchestration Tool",
             config: { file: "missing/parameters.json", path: "$[?@.ParameterKey=='X']" },
@@ -95,7 +95,7 @@ describe("loadStackOrch", () => {
           component: "backend",
           promotionType: "securePipelines",
           automated: [{
-            checks: [{ name: "product" }],
+            checks: [{ name: "integration" }],
             phase: "build",
             provider: "Stack Orchestration Tool",
             config: { file: relPath, path: "$[?@.ParameterKey=='TestImageRepositoryUri']" },

--- a/cli/middleware/load-terraform.test.js
+++ b/cli/middleware/load-terraform.test.js
@@ -41,7 +41,7 @@ describe("loadTerraform", () => {
           component: "infra",
           promotionType: "securePipelines",
           automated: [{
-            checks: [{ name: "product" }],
+            checks: [{ name: "integration" }],
             phase: "build",
             provider: "Terraform",
             config: { file: "terraform/main.tf", path: "$.module.deploy.parameters.X" },
@@ -63,7 +63,7 @@ describe("loadTerraform", () => {
           component: "infra",
           promotionType: "securePipelines",
           automated: [{
-            checks: [{ name: "product" }],
+            checks: [{ name: "integration" }],
             phase: "build",
             provider: "Terraform",
             config: { file: "some-file.json", path: "$.x" },

--- a/cli/upgrades/index.js
+++ b/cli/upgrades/index.js
@@ -7,6 +7,7 @@ import { transform as v0120 } from "./v0.12.0.js";
 import { transform as v0130 } from "./v0.13.0.js";
 import { transform as v0140 } from "./v0.14.0.js";
 import { transform as v0150 } from "./v0.15.0.js";
+import { transform as v0160 } from "./v0.16.0.js";
 
 const SCHEMA_URL_PREFIX = "https://raw.githubusercontent.com/govuk-one-login/quality-gates/refs/tags/v";
 
@@ -20,6 +21,7 @@ const transforms = [
   { version: [0, 13, 0], transform: v0130 },
   { version: [0, 14, 0], transform: v0140 },
   { version: [0, 15, 0], transform: v0150 },
+  { version: [0, 16, 0], transform: v0160 },
 ];
 
 export function parseVersion(schema) {

--- a/cli/upgrades/upgrades.test.js
+++ b/cli/upgrades/upgrades.test.js
@@ -10,6 +10,7 @@ import { transform as v0120 } from "./v0.12.0.js";
 import { transform as v0130 } from "./v0.13.0.js";
 import { transform as v0140 } from "./v0.14.0.js";
 import { transform as v0150 } from "./v0.15.0.js";
+import { transform as v0160 } from "./v0.16.0.js";
 
 describe("parseVersion", () => {
   it("extracts version from schema URL", () => {
@@ -25,38 +26,41 @@ describe("parseVersion", () => {
 
 describe("getTransforms", () => {
   it("returns all transforms for null version", () => {
-    assert.equal(getTransforms(null).length, 9);
+    assert.equal(getTransforms(null).length, 10);
   });
   it("returns all transforms for v0.1.0", () => {
-    assert.equal(getTransforms([0, 1, 0]).length, 9);
+    assert.equal(getTransforms([0, 1, 0]).length, 10);
   });
-  it("returns v0.7.0 through v0.15.0 for v0.5.0", () => {
+  it("returns v0.7.0 through v0.16.0 for v0.5.0", () => {
     const t = getTransforms([0, 5, 0]);
-    assert.equal(t.length, 8);
+    assert.equal(t.length, 9);
   });
-  it("returns v0.9.0 through v0.15.0 for v0.7.0", () => {
-    assert.equal(getTransforms([0, 7, 0]).length, 7);
+  it("returns v0.9.0 through v0.16.0 for v0.7.0", () => {
+    assert.equal(getTransforms([0, 7, 0]).length, 8);
   });
-  it("returns v0.10.0 through v0.15.0 for v0.9.0", () => {
-    assert.equal(getTransforms([0, 9, 0]).length, 6);
+  it("returns v0.10.0 through v0.16.0 for v0.9.0", () => {
+    assert.equal(getTransforms([0, 9, 0]).length, 7);
   });
-  it("returns v0.11.0 through v0.15.0 for v0.10.0", () => {
-    assert.equal(getTransforms([0, 10, 0]).length, 5);
+  it("returns v0.11.0 through v0.16.0 for v0.10.0", () => {
+    assert.equal(getTransforms([0, 10, 0]).length, 6);
   });
-  it("returns v0.12.0 through v0.15.0 for v0.11.0", () => {
-    assert.equal(getTransforms([0, 11, 0]).length, 4);
+  it("returns v0.12.0 through v0.16.0 for v0.11.0", () => {
+    assert.equal(getTransforms([0, 11, 0]).length, 5);
   });
-  it("returns v0.13.0 through v0.15.0 for v0.12.0", () => {
-    assert.equal(getTransforms([0, 12, 0]).length, 3);
+  it("returns v0.13.0 through v0.16.0 for v0.12.0", () => {
+    assert.equal(getTransforms([0, 12, 0]).length, 4);
   });
-  it("returns v0.14.0 and v0.15.0 for v0.13.0", () => {
-    assert.equal(getTransforms([0, 13, 0]).length, 2);
+  it("returns v0.14.0 through v0.16.0 for v0.13.0", () => {
+    assert.equal(getTransforms([0, 13, 0]).length, 3);
   });
-  it("returns only v0.15.0 for v0.14.0", () => {
-    assert.equal(getTransforms([0, 14, 0]).length, 1);
+  it("returns v0.15.0 and v0.16.0 for v0.14.0", () => {
+    assert.equal(getTransforms([0, 14, 0]).length, 2);
   });
-  it("returns nothing for v0.15.0", () => {
-    assert.equal(getTransforms([0, 15, 0]).length, 0);
+  it("returns only v0.16.0 for v0.15.0", () => {
+    assert.equal(getTransforms([0, 15, 0]).length, 1);
+  });
+  it("returns nothing for v0.16.0", () => {
+    assert.equal(getTransforms([0, 16, 0]).length, 0);
   });
 });
 
@@ -304,8 +308,83 @@ describe("v0.15.0 transform", () => {
   });
 });
 
+describe("v0.16.0 transform", () => {
+  it("converts scope-mappable check types to integration with scope", () => {
+    const input = {
+      $schema: schemaUrl("0.15.0"),
+      services: [{ product: "svc", component: "api", promotionType: "securePipelines", automated: [{ checks: [{ name: "component" }, { name: "integration" }], phase: "pre-merge", provider: "GitHub", config: { file: "a.yml", path: "$.jobs.test" } }] }],
+    };
+    const result = v0160(input);
+    assert.equal(result.$schema, schemaUrl("0.16.0"));
+    assert.deepEqual(result.services[0].automated[0].checks, [{ name: "integration", scope: "component" }]);
+  });
+
+  it("converts purpose-mappable check types to purpose on unit", () => {
+    const input = {
+      $schema: schemaUrl("0.15.0"),
+      services: [{ product: "svc", component: "api", promotionType: "securePipelines", automated: [{ checks: [{ name: "unit" }, { name: "regression" }, { name: "new feature" }], phase: "pre-merge", provider: "GitHub", config: { file: "a.yml", path: "$.jobs.test" } }] }],
+    };
+    const result = v0160(input);
+    assert.deepEqual(result.services[0].automated[0].checks, [{ name: "unit", purpose: ["regression", "new feature"] }]);
+  });
+
+  it("converts purpose-mappable to purpose on integration when no unit", () => {
+    const input = {
+      $schema: schemaUrl("0.15.0"),
+      services: [{ product: "svc", component: "api", promotionType: "securePipelines", automated: [{ checks: [{ name: "integration" }, { name: "regression" }], phase: "pre-merge", provider: "GitHub", config: { file: "a.yml", path: "$.jobs.test" } }] }],
+    };
+    const result = v0160(input);
+    assert.deepEqual(result.services[0].automated[0].checks, [{ name: "integration", purpose: ["regression"] }]);
+  });
+
+  it("infers integration when only purpose values present", () => {
+    const input = {
+      $schema: schemaUrl("0.15.0"),
+      services: [{ product: "svc", component: "api", promotionType: "securePipelines", automated: [{ checks: [{ name: "regression" }, { name: "smoke" }], phase: "pre-merge", provider: "GitHub", config: { file: "a.yml", path: "$.jobs.test" } }] }],
+    };
+    const result = v0160(input);
+    assert.deepEqual(result.services[0].automated[0].checks, [{ name: "integration", purpose: ["regression", "smoke"] }]);
+  });
+
+  it("converts stack to integration with scope component", () => {
+    const input = {
+      $schema: schemaUrl("0.15.0"),
+      services: [{ product: "svc", component: "api", promotionType: "securePipelines", automated: [{ checks: [{ name: "stack" }], phase: "pre-merge", provider: "GitHub", config: { file: "a.yml", path: "$.jobs.test" } }] }],
+    };
+    const result = v0160(input);
+    assert.deepEqual(result.services[0].automated[0].checks, [{ name: "integration", scope: "component" }]);
+  });
+
+  it("merges scope and purpose into single integration entry", () => {
+    const input = {
+      $schema: schemaUrl("0.15.0"),
+      services: [{ product: "svc", component: "api", promotionType: "securePipelines", automated: [{ checks: [{ name: "component" }, { name: "integration" }, { name: "regression" }, { name: "new feature" }], phase: "pre-merge", provider: "GitHub", config: { file: "a.yml", path: "$.jobs.test" } }] }],
+    };
+    const result = v0160(input);
+    assert.deepEqual(result.services[0].automated[0].checks, [{ name: "integration", purpose: ["regression", "new feature"], scope: "component" }]);
+  });
+
+  it("leaves non-affected checks unchanged", () => {
+    const input = {
+      $schema: schemaUrl("0.15.0"),
+      services: [{ product: "svc", component: "api", promotionType: "securePipelines", automated: [{ checks: [{ name: "unit" }, { name: "code style and linting" }], phase: "pre-merge", provider: "GitHub", config: { file: "a.yml", path: "$.jobs.test" } }] }],
+    };
+    const result = v0160(input);
+    assert.deepEqual(result.services[0].automated[0].checks, [{ name: "unit" }, { name: "code style and linting" }]);
+  });
+
+  it("handles services with no execution modes", () => {
+    const input = {
+      $schema: schemaUrl("0.15.0"),
+      services: [{ product: "svc", component: "api", promotionType: "securePipelines" }],
+    };
+    const result = v0160(input);
+    assert.equal(result.services[0].automated, undefined);
+  });
+});
+
 describe("full pipeline", () => {
-  it("upgrades v0.1.0 manifest to v0.15.0", () => {
+  it("upgrades v0.1.0 manifest to v0.16.0", () => {
     const input = {
       $schema: "https://raw.githubusercontent.com/govuk-one-login/quality-gates/refs/tags/v0.1.0/schemas/schema.json",
       services: [{
@@ -322,14 +401,11 @@ describe("full pipeline", () => {
       result = transform(result);
     }
 
-    assert.equal(result.$schema, schemaUrl("0.15.0"));
+    assert.equal(result.$schema, schemaUrl("0.16.0"));
     assert.equal(result.services[0].product, "example");
     assert.equal(result.services[0].component, "example");
-    assert.equal(result.services[0].serviceTag, undefined);
     assert.equal(result.services[0].promotionType, "securePipelines");
     assert.deepEqual(result.services[0].automated[0].checks, [{ name: "integration" }]);
-    assert.equal(result.services[0].automated[0].checkTypes, undefined);
-    assert.equal(result.services[0].automated[0].provider, "Stack Orchestration Tool");
     assert.equal(result.services[0].automated[0].config.path, "$.jobs.build");
     assert.equal(result.services[0].automated[0].config.name, undefined);
   });

--- a/cli/upgrades/v0.16.0.js
+++ b/cli/upgrades/v0.16.0.js
@@ -1,0 +1,98 @@
+import { schemaUrl } from "./index.js";
+
+const SCOPE_MAP = {
+  component: "component",
+  product: "product",
+  neighbour: "neighbour",
+  e2e: "e2e",
+  stack: "component",
+};
+
+const PURPOSE_SET = new Set(["regression", "new feature", "smoke"]);
+
+function transformChecksArray(checks) {
+  const scopeValues = [];
+  const purposeValues = [];
+  const kept = [];
+
+  for (const check of checks) {
+    if (SCOPE_MAP[check.name]) {
+      scopeValues.push(SCOPE_MAP[check.name]);
+    } else if (PURPOSE_SET.has(check.name)) {
+      purposeValues.push(check.name);
+    } else {
+      kept.push(check);
+    }
+  }
+
+  if (scopeValues.length === 0 && purposeValues.length === 0) {
+    return checks;
+  }
+
+  // Determine purpose target: unit > integration > infer integration
+  const unitIndex = kept.findIndex((c) => c.name === "unit");
+  const integrationIndex = kept.findIndex((c) => c.name === "integration");
+
+  if (unitIndex !== -1 && purposeValues.length > 0) {
+    kept[unitIndex] = { ...kept[unitIndex], purpose: purposeValues };
+  } else if (integrationIndex !== -1 && purposeValues.length > 0) {
+    kept[integrationIndex] = { ...kept[integrationIndex], purpose: purposeValues };
+  } else if (purposeValues.length > 0 && scopeValues.length === 0) {
+    kept.push({ name: "integration", purpose: purposeValues });
+  }
+
+  // Each scope creates an integration entry with purposes (if not already attached to unit)
+  for (const scope of scopeValues) {
+    const entry = { name: "integration", scope };
+    if (purposeValues.length > 0 && unitIndex === -1) {
+      entry.purpose = purposeValues;
+    }
+    // If there's already an integration entry from the kept array, merge scope into it
+    const existingIntegration = kept.findIndex(
+      (c) => c.name === "integration" && !c.scope
+    );
+    if (existingIntegration !== -1) {
+      kept[existingIntegration] = { ...kept[existingIntegration], scope };
+    } else {
+      kept.push(entry);
+    }
+  }
+
+  return kept;
+}
+
+export function transform(manifest) {
+  return {
+    $schema: schemaUrl("0.16.0"),
+    services: (manifest.services || []).map((service) => {
+      const result = { ...service };
+
+      for (const mode of ["automated", "manual", "outOfBand"]) {
+        if (result[mode]) {
+          result[mode] = result[mode].map((gate) => ({
+            ...gate,
+            checks: transformChecksArray(gate.checks || []),
+          }));
+        }
+      }
+
+      if (result.notApplicable) {
+        result.notApplicable = result.notApplicable.map((gate) => ({
+          ...gate,
+          checks: (gate.checks || []).filter(
+            (c) => !SCOPE_MAP[c.name] && !PURPOSE_SET.has(c.name)
+          ),
+        }));
+        // Remove empty notApplicable entries
+        result.notApplicable = result.notApplicable.filter(
+          (gate) => gate.checks.length > 0
+        );
+        if (result.notApplicable.length === 0) {
+          delete result.notApplicable;
+        }
+      }
+
+      return result;
+    }),
+  };
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,6 +52,13 @@ The schema supports three deployment strategy models, each with different phase 
 
 Check types are drawn from prior analysis work within the GOV.UK One Login programme. They represent categories of verification, not specific tools. For example, `unit` covers any unit testing framework, and `secret scanning` covers any tool that detects secrets.
 
+The `integration` and `unit` check types support additional metadata:
+
+- **Scope** (integration only) — describes the breadth of what is being tested: `component`, `product`, `neighbour`, or `e2e`
+- **Purpose** (integration and unit) — describes why the test exists: `regression`, `new feature`, `smoke`, or `performance`
+
+These were previously standalone check types but have been consolidated as attributes of integration/unit checks to provide richer, composable descriptions.
+
 ## Design decisions
 
 ### Schema-based approach

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,7 +10,7 @@ Add a `$schema` property pointing to a tagged release:
 
 ```json
 {
-  "$schema": "https://raw.githubusercontent.com/govuk-one-login/quality-gates/refs/tags/v0.15.0/schemas/schema.json"
+  "$schema": "https://raw.githubusercontent.com/govuk-one-login/quality-gates/refs/tags/v0.16.0/schemas/schema.json"
 }
 ```
 
@@ -95,6 +95,7 @@ The upgrade command handles all historical schema migrations automatically, incl
 - `serviceTag` → `product`/`component` (v0.13.0)
 - `checks` → `automated` execution mode split (v0.14.0)
 - `checkTypes` string array → `checks` object array (v0.15.0)
+- Add `scope`/`purpose` to checks, remove deprecated check types (v0.16.0)
 
 ### Exit codes
 
@@ -178,9 +179,33 @@ Check types that the team has consciously decided do not apply to this service.
 
 Each item in a `checks` array is an object:
 
-| Field  | Type   | Required | Description                              |
-|--------|--------|----------|------------------------------------------|
-| `name` | string | Yes      | Check type name (from the allowed enum)  |
+| Field     | Type     | Required | Description                              |
+|-----------|----------|----------|------------------------------------------|
+| `name`    | string   | Yes      | Check type name (from the allowed enum)  |
+| `scope`   | string   | No       | Scope of an integration check (only allowed when `name` is `"integration"`) |
+| `purpose` | string[] | No       | Purpose of the check (only allowed when `name` is `"integration"` or `"unit"`) |
+
+#### Scope values
+
+Only applicable to `integration` checks:
+
+| Value | Description |
+|-------|-------------|
+| `component` | Tests a single component in isolation |
+| `product` | Tests the full product/service |
+| `neighbour` | Tests interaction with neighbouring services |
+| `e2e` | End-to-end tests across the full stack |
+
+#### Purpose values
+
+Applicable to `integration` and `unit` checks:
+
+| Value | Description |
+|-------|-------------|
+| `regression` | Verifies existing functionality hasn't broken |
+| `new feature` | Validates new functionality |
+| `smoke` | Quick sanity check that critical paths work |
+| `performance` | Validates performance characteristics |
 
 ### Checks with details
 
@@ -189,13 +214,15 @@ In `notApplicable`, each check item also requires justification:
 | Field     | Type     | Required | Description                                   |
 |-----------|----------|----------|-----------------------------------------------|
 | `name`    | string   | Yes      | Check type name (from the allowed enum)       |
+| `scope`   | string   | No       | Scope (same rules as above)                   |
+| `purpose` | string[] | No       | Purpose (same rules as above)                 |
 | `details` | string[] | Yes      | Justification for why it is not applicable    |
 
 ### Check types
 
 The schema supports the following check-type values:
 
-`accessibility`, `canary`, `code quality`, `code style and linting`, `component`, `contract`, `cross service integration`, `data compatibility`, `e2e`, `integration`, `neighbour`, `new feature`, `product`, `regression`, `secret scanning`, `sensitive data scanning`, `smoke`, `stack`, `system`, `unit test coverage`, `unit`, `visual regression`, `vulnerability detection`
+`accessibility`, `canary`, `code quality`, `code style and linting`, `contract`, `cross service integration`, `data compatibility`, `integration`, `secret scanning`, `sensitive data scanning`, `system`, `unit test coverage`, `unit`, `visual regression`, `vulnerability detection`
 
 ### Phases
 

--- a/examples/github-gitflow.json
+++ b/examples/github-gitflow.json
@@ -33,7 +33,7 @@
           }
         },
         {
-          "checks": [{ "name": "e2e" }],
+          "checks": [{ "name": "integration", "scope": "e2e" }],
           "provider": "GitHub",
           "phase": "release",
           "config": {
@@ -42,7 +42,7 @@
           }
         },
         {
-          "checks": [{ "name": "smoke" }],
+          "checks": [{ "name": "integration", "purpose": ["smoke"] }],
           "provider": "GitHub",
           "phase": "main",
           "config": {

--- a/schemas/schema.json
+++ b/schemas/schema.json
@@ -32,31 +32,41 @@
   },
   "$defs": {
     "check-type": {
-      "description": "A quality check category as documented, plus emergent checks",
+      "description": "A quality check category",
       "enum": [
         "accessibility",
         "canary",
         "code quality",
         "code style and linting",
-        "component",
         "contract",
         "cross service integration",
         "data compatibility",
-        "e2e",
-        "neighbour",
-        "new feature",
-        "product",
-        "regression",
+        "integration",
         "secret scanning",
         "sensitive data scanning",
-        "smoke",
-        "stack",
         "system",
         "unit test coverage",
         "unit",
         "visual regression",
-        "vulnerability detection",
-        "integration"
+        "vulnerability detection"
+      ]
+    },
+    "scope": {
+      "description": "The scope of an integration check",
+      "enum": [
+        "component",
+        "product",
+        "neighbour",
+        "e2e"
+      ]
+    },
+    "purpose": {
+      "description": "The purpose of a check",
+      "enum": [
+        "regression",
+        "new feature",
+        "smoke",
+        "performance"
       ]
     },
     "check": {
@@ -64,9 +74,40 @@
       "properties": {
         "name": {
           "$ref": "#/$defs/check-type"
+        },
+        "scope": {
+          "$ref": "#/$defs/scope"
+        },
+        "purpose": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/purpose"
+          }
         }
       },
-      "required": ["name"]
+      "required": ["name"],
+      "allOf": [
+        {
+          "if": {
+            "not": {
+              "properties": { "name": { "const": "integration" } }
+            }
+          },
+          "then": {
+            "not": { "required": ["scope"] }
+          }
+        },
+        {
+          "if": {
+            "not": {
+              "properties": { "name": { "enum": ["integration", "unit"] } }
+            }
+          },
+          "then": {
+            "not": { "required": ["purpose"] }
+          }
+        }
+      ]
     },
     "check-with-details": {
       "type": "object",
@@ -74,13 +115,44 @@
         "name": {
           "$ref": "#/$defs/check-type"
         },
+        "scope": {
+          "$ref": "#/$defs/scope"
+        },
+        "purpose": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/purpose"
+          }
+        },
         "details": {
           "type": "array",
           "items": { "type": "string" },
           "minItems": 1
         }
       },
-      "required": ["name", "details"]
+      "required": ["name", "details"],
+      "allOf": [
+        {
+          "if": {
+            "not": {
+              "properties": { "name": { "const": "integration" } }
+            }
+          },
+          "then": {
+            "not": { "required": ["scope"] }
+          }
+        },
+        {
+          "if": {
+            "not": {
+              "properties": { "name": { "enum": ["integration", "unit"] } }
+            }
+          },
+          "then": {
+            "not": { "required": ["purpose"] }
+          }
+        }
+      ]
     },
     "checks": {
       "type": "array",

--- a/test/check-types.json
+++ b/test/check-types.json
@@ -1,9 +1,9 @@
 {
   "target": "../schemas/schema.json",
-  "$comment": "Check type tests",
+  "$comment": "Check type, scope, and purpose tests",
   "tests": [
     {
-      "description": "Service with integration check - to be deprecated in the future",
+      "description": "integration check with scope is valid",
       "valid": true,
       "data": {
         "services": [
@@ -13,7 +13,79 @@
             "promotionType": "securePipelines",
             "automated": [
               {
-                "checks": [{ "name": "integration" }],
+                "checks": [{ "name": "integration", "scope": "component" }],
+                "provider": "GitHub",
+                "phase": "pre-merge",
+                "config": {
+                  "file": ".github/workflows/tests.yaml",
+                  "path": "$.jobs.integration"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "description": "integration check with purpose is valid",
+      "valid": true,
+      "data": {
+        "services": [
+          {
+            "product": "generic-service",
+            "component": "api",
+            "promotionType": "securePipelines",
+            "automated": [
+              {
+                "checks": [{ "name": "integration", "purpose": ["regression", "new feature"] }],
+                "provider": "GitHub",
+                "phase": "pre-merge",
+                "config": {
+                  "file": ".github/workflows/tests.yaml",
+                  "path": "$.jobs.integration"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "description": "integration check with scope and purpose is valid",
+      "valid": true,
+      "data": {
+        "services": [
+          {
+            "product": "generic-service",
+            "component": "api",
+            "promotionType": "securePipelines",
+            "automated": [
+              {
+                "checks": [{ "name": "integration", "scope": "e2e", "purpose": ["smoke"] }],
+                "provider": "GitHub",
+                "phase": "pre-merge",
+                "config": {
+                  "file": ".github/workflows/tests.yaml",
+                  "path": "$.jobs.e2e"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "description": "unit check with purpose is valid",
+      "valid": true,
+      "data": {
+        "services": [
+          {
+            "product": "generic-service",
+            "component": "api",
+            "promotionType": "securePipelines",
+            "automated": [
+              {
+                "checks": [{ "name": "unit", "purpose": ["regression"] }],
                 "provider": "GitHub",
                 "phase": "pre-merge",
                 "config": {
@@ -27,8 +99,56 @@
       }
     },
     {
-      "description": "Service with component check",
-      "valid": true,
+      "description": "scope on non-integration check is invalid",
+      "valid": false,
+      "data": {
+        "services": [
+          {
+            "product": "generic-service",
+            "component": "api",
+            "promotionType": "securePipelines",
+            "automated": [
+              {
+                "checks": [{ "name": "unit", "scope": "component" }],
+                "provider": "GitHub",
+                "phase": "pre-merge",
+                "config": {
+                  "file": ".github/workflows/tests.yaml",
+                  "path": "$.jobs.unit"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "description": "purpose on non-integration non-unit check is invalid",
+      "valid": false,
+      "data": {
+        "services": [
+          {
+            "product": "generic-service",
+            "component": "api",
+            "promotionType": "securePipelines",
+            "automated": [
+              {
+                "checks": [{ "name": "code quality", "purpose": ["regression"] }],
+                "provider": "GitHub",
+                "phase": "pre-merge",
+                "config": {
+                  "file": ".github/workflows/tests.yaml",
+                  "path": "$.jobs.quality"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "description": "removed check type component is invalid",
+      "valid": false,
       "data": {
         "services": [
           {
@@ -51,56 +171,8 @@
       }
     },
     {
-      "description": "Service with product check",
-      "valid": true,
-      "data": {
-        "services": [
-          {
-            "product": "generic-service",
-            "component": "api",
-            "promotionType": "securePipelines",
-            "automated": [
-              {
-                "checks": [{ "name": "product" }],
-                "provider": "GitHub",
-                "phase": "pre-merge",
-                "config": {
-                  "file": ".github/workflows/tests.yaml",
-                  "path": "$.jobs.unit"
-                }
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "description": "Service with neighbour check",
-      "valid": true,
-      "data": {
-        "services": [
-          {
-            "product": "generic-service",
-            "component": "api",
-            "promotionType": "securePipelines",
-            "automated": [
-              {
-                "checks": [{ "name": "neighbour" }],
-                "provider": "GitHub",
-                "phase": "pre-merge",
-                "config": {
-                  "file": ".github/workflows/tests.yaml",
-                  "path": "$.jobs.unit"
-                }
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "description": "Service with e2e check",
-      "valid": true,
+      "description": "removed check type e2e is invalid",
+      "valid": false,
       "data": {
         "services": [
           {
@@ -115,6 +187,54 @@
                 "config": {
                   "file": ".github/workflows/tests.yaml",
                   "path": "$.jobs.unit"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "description": "removed check type regression is invalid",
+      "valid": false,
+      "data": {
+        "services": [
+          {
+            "product": "generic-service",
+            "component": "api",
+            "promotionType": "securePipelines",
+            "automated": [
+              {
+                "checks": [{ "name": "regression" }],
+                "provider": "GitHub",
+                "phase": "pre-merge",
+                "config": {
+                  "file": ".github/workflows/tests.yaml",
+                  "path": "$.jobs.unit"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "description": "integration check without scope or purpose is valid",
+      "valid": true,
+      "data": {
+        "services": [
+          {
+            "product": "generic-service",
+            "component": "api",
+            "promotionType": "securePipelines",
+            "automated": [
+              {
+                "checks": [{ "name": "integration" }],
+                "provider": "GitHub",
+                "phase": "pre-merge",
+                "config": {
+                  "file": ".github/workflows/tests.yaml",
+                  "path": "$.jobs.integration"
                 }
               }
             ]

--- a/visualiser/src/components/manifest-and-workflows.test.js
+++ b/visualiser/src/components/manifest-and-workflows.test.js
@@ -79,7 +79,7 @@ describe("manifest-and-workflows", () => {
                                             }
                                         },
                                         {
-                                            "checks": [{ "name": "component" }, { "name": "regression" }],
+                                            "checks": [{ "name": "integration", "scope": "component", "purpose": ["regression"] }],
                                             "config": {
                                                 file: ".github/workflows/ci.yaml",
                                                 path: "$.jobs.integration-test"
@@ -165,7 +165,7 @@ describe("manifest-and-workflows", () => {
                     }
                 },
                 {
-                    "checkTypes": ["component", "regression"],
+                    "checkTypes": ["integration"],
                     "job": {
                         "__workflow-file": "ci.yaml",
                         "__workflow-name": "CI",


### PR DESCRIPTION
Scope is now to be used where previously the checkType of
component/product/neighbour/e2e was used

Purpose is to be used where previously the checkType of
regression / new feature / smoke was used.

performance has been added as an additional purpose check

component/product/neighbour/e2e/regression/new feature/smoke have all been removed as checkTypes